### PR TITLE
Responsive UI pass: mobile-first layout, tables & charts

### DIFF
--- a/app/backtester/page.tsx
+++ b/app/backtester/page.tsx
@@ -93,24 +93,24 @@ export default function BacktesterPage() {
 
   return (
     <main className="min-h-screen bg-gray-900">
-      <div className="container mx-auto px-6 py-8">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
+        <div className="mb-8 space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-3 text-sm sm:text-base">
               <Link
                 href="/dashboard"
-                className="flex items-center text-gray-400 hover:text-white transition-colors"
+                className="inline-flex items-center text-gray-400 hover:text-white transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
               >
                 <ArrowLeft className="w-4 h-4 mr-1" />
                 Back to Dashboard
               </Link>
             </div>
 
-            <div className="flex space-x-3">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
               <Link
                 href="/data"
-                className="flex items-center px-4 py-2 border border-gray-600 text-gray-300 hover:text-white hover:border-gray-500 rounded-lg transition-colors"
+                className="inline-flex items-center justify-center px-4 py-3 sm:py-2 border border-gray-600 text-gray-300 hover:text-white hover:border-gray-500 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
               >
                 <Database className="w-4 h-4 mr-2" />
                 Data Explorer
@@ -118,12 +118,12 @@ export default function BacktesterPage() {
             </div>
           </div>
 
-          <div className="mt-4">
-            <h1 className="text-3xl font-bold text-white mb-2">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-white">
               <Sparkles className="inline w-8 h-8 mr-2 text-blue-400" />
               AI Strategy Backtester
             </h1>
-            <p className="text-gray-400 text-lg">
+            <p className="mt-2 text-sm sm:text-base text-gray-400">
               Describe your trading strategy in plain English and let AI generate and test it for you
             </p>
           </div>
@@ -138,19 +138,19 @@ export default function BacktesterPage() {
         {error && (
           <div className="mb-8 p-4 bg-red-900/30 border border-red-500/50 rounded-lg">
             <h3 className="text-red-200 font-medium mb-2">Error</h3>
-            <p className="text-red-300">{error}</p>
+            <p className="text-sm sm:text-base text-red-300">{error}</p>
           </div>
         )}
 
         {/* Loading State */}
         {loading && (
-          <div className="mb-8 bg-gray-800 rounded-lg p-8 text-center">
+          <div className="mb-8 bg-gray-800 rounded-lg p-6 sm:p-8 text-center">
             <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-            <h3 className="text-xl font-semibold text-white mb-2">Processing Strategy</h3>
-            <p className="text-gray-400">
+            <h3 className="text-lg sm:text-xl font-semibold text-white mb-2">Processing Strategy</h3>
+            <p className="text-sm sm:text-base text-gray-400">
               AI is generating your strategy and running the backtest...
             </p>
-            <div className="mt-4 space-y-2 text-sm text-gray-500">
+            <div className="mt-4 space-y-2 text-sm sm:text-base text-gray-500">
               <div>🤖 Analyzing your strategy description...</div>
               <div>⚡ Generating trading rules...</div>
               <div>📊 Running backtest simulation...</div>
@@ -166,16 +166,16 @@ export default function BacktesterPage() {
 
         {/* Help Section */}
         {!loading && !results && !error && (
-          <div className="mt-12 bg-gray-800 rounded-lg p-6">
-            <h3 className="text-lg font-semibold text-white mb-4">How It Works</h3>
+          <div className="mt-12 bg-gray-800 rounded-lg p-5 sm:p-6">
+            <h3 className="text-lg sm:text-xl font-semibold text-white mb-4">How It Works</h3>
 
-            <div className="grid md:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
                 <h4 className="text-blue-400 font-medium mb-2">Rule-Based Strategies (DSL)</h4>
-                <p className="text-gray-400 text-sm mb-3">
+                <p className="text-gray-400 text-sm sm:text-base mb-3">
                   Perfect for technical analysis strategies using indicators like moving averages, RSI, and MACD.
                 </p>
-                <ul className="text-gray-400 text-sm space-y-1">
+                <ul className="text-gray-400 text-sm sm:text-base space-y-1">
                   <li>• SMA/EMA crossover strategies</li>
                   <li>• RSI overbought/oversold levels</li>
                   <li>• MACD signal line crossovers</li>
@@ -185,10 +185,10 @@ export default function BacktesterPage() {
 
               <div>
                 <h4 className="text-purple-400 font-medium mb-2">Machine Learning Strategies</h4>
-                <p className="text-gray-400 text-sm mb-3">
+                <p className="text-gray-400 text-sm sm:text-base mb-3">
                   Advanced strategies using AI models to predict price movements and make trading decisions.
                 </p>
-                <ul className="text-gray-400 text-sm space-y-1">
+                <ul className="text-gray-400 text-sm sm:text-base space-y-1">
                   <li>• Random Forest classifiers</li>
                   <li>• Linear regression models</li>
                   <li>• Decision tree algorithms</li>
@@ -202,7 +202,7 @@ export default function BacktesterPage() {
 
             <div className="mt-6 p-4 bg-blue-900/20 border border-blue-500/30 rounded">
               <h4 className="text-blue-300 font-medium mb-2">💡 Pro Tips</h4>
-              <ul className="text-blue-200 text-sm space-y-1">
+              <ul className="text-blue-200 text-sm sm:text-base space-y-1">
                 <li>• Be specific about entry and exit conditions</li>
                 <li>• Mention specific indicator periods (e.g., "10-day SMA")</li>
                 <li>• Test on multiple tickers to validate robustness</li>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -17,102 +17,101 @@ function DashboardInner() {
     if (t) setSelectedTicker(t.toUpperCase());
   }, [searchParams]);
 
-return (
+  return (
     <Suspense fallback={<div className="p-6 text-gray-300">Loading…</div>}>
       <main className="min-h-screen bg-gray-900">
-      <div className="container mx-auto px-6 py-8">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-white mb-2">Dashboard</h1>
-          <p className="text-gray-400">
-            Real-time overview of available stock tickers and price data visualization
-          </p>
-        </div>
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+          <div className="mb-8 space-y-4">
+            <h1 className="text-2xl sm:text-3xl font-bold text-white">Dashboard</h1>
+            <p className="text-sm sm:text-base text-gray-400">
+              Real-time overview of available stock tickers and price data visualization
+            </p>
+          </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Ticker Selection Panel */}
-          <div className="lg:col-span-1">
-            <TickerSelector
-              onTickerSelect={setSelectedTicker}
-              selectedTicker={selectedTicker}
-            />
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6">
+            {/* Ticker Selection Panel */}
+            <div className="lg:col-span-1 order-2 lg:order-1">
+              <TickerSelector
+                onTickerSelect={setSelectedTicker}
+                selectedTicker={selectedTicker}
+              />
 
-            {selectedTicker && (
-              <div className="mt-4 p-4 bg-blue-900/30 rounded-lg border border-blue-700">
-                <h4 className="text-white font-medium mb-2">Selected</h4>
-                <div className="text-blue-200">
-                  <div className="text-lg font-bold">{selectedTicker}</div>
-                  <div className="text-sm text-blue-300">
-                    Click a ticker to view its price chart and data
+              {selectedTicker && (
+                <div className="mt-4 p-4 bg-blue-900/30 rounded-lg border border-blue-700">
+                  <h4 className="text-lg sm:text-xl font-semibold text-white mb-2">Selected</h4>
+                  <div className="text-blue-200">
+                    <div className="text-base sm:text-lg font-bold">{selectedTicker}</div>
+                    <div className="text-sm text-blue-300">
+                      Click a ticker to view its price chart and data
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
 
-            <div className="mt-4 p-3 bg-gray-800 rounded-lg text-sm">
-              <h4 className="text-white font-medium mb-2">Quick Actions</h4>
-              <div className="space-y-2">
-                <Link
-                  href="/backtester"
-                  className="block w-full text-left px-3 py-2 bg-green-600 hover:bg-green-700 rounded text-white transition-colors"
-                >
-                  → Test Trading Strategy
-                </Link>
-                <Link
-                  href="/data"
-                  className="block w-full text-left px-3 py-2 bg-purple-600 hover:bg-purple-700 rounded text-white transition-colors"
-                >
-                  → Explore Data
-                </Link>
-              </div>
-            </div>
-          </div>
-
-          {/* Chart Panel */}
-          <div className="lg:col-span-2">
-            {selectedTicker ? (
-              <PriceChart ticker={selectedTicker} />
-            ) : (
-              <div className="bg-gray-800 rounded-lg p-8 text-center">
-                <div className="text-gray-400 mb-4">
-                  <svg className="w-16 h-16 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a 2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                  </svg>
+              <div className="mt-4 p-3 bg-gray-800 rounded-lg text-sm">
+                <h4 className="text-lg sm:text-xl font-semibold text-white mb-2">Quick Actions</h4>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <Link
+                    href="/backtester"
+                    className="w-full text-left px-3 py-3 sm:py-2 bg-green-600 hover:bg-green-700 rounded text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                  >
+                    → Test Trading Strategy
+                  </Link>
+                  <Link
+                    href="/data"
+                    className="w-full text-left px-3 py-3 sm:py-2 bg-purple-600 hover:bg-purple-700 rounded text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                  >
+                    → Explore Data
+                  </Link>
                 </div>
-                <h3 className="text-xl font-semibold text-white mb-2">
-                  Select a Ticker to View Chart
-                </h3>
-                <p className="text-gray-400">
-                  Choose a stock ticker from the list on the left to display its historical price data and interactive chart.
-                </p>
               </div>
-            )}
-          </div>
-        </div>
+            </div>
 
-        {/* Status Bar */}
-        <div className="mt-8 p-4 bg-gray-800 rounded-lg border border-gray-700">
-          <div className="flex items-center justify-between text-sm">
-            <div className="flex items-center space-x-4">
-              <div className="flex items-center">
-                <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
-                <span className="text-gray-300">Data Source: S3</span>
-              </div>
-              <div className="flex items-center">
-                <div className="w-2 h-2 bg-blue-500 rounded-full mr-2"></div>
-                <span className="text-gray-300">API Status: Active</span>
-              </div>
+            {/* Chart Panel */}
+            <div className="lg:col-span-2 order-1 lg:order-2">
+              {selectedTicker ? (
+                <PriceChart ticker={selectedTicker} />
+              ) : (
+                <div className="bg-gray-800 rounded-lg p-6 sm:p-8 text-center">
+                  <div className="text-gray-400 mb-4">
+                    <svg className="w-16 h-16 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a 2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                    </svg>
+                  </div>
+                  <h3 className="text-lg sm:text-xl font-semibold text-white mb-2">
+                    Select a Ticker to View Chart
+                  </h3>
+                  <p className="text-sm sm:text-base text-gray-400">
+                    Choose a stock ticker from the list on the left to display its historical price data and interactive chart.
+                  </p>
+                </div>
+              )}
             </div>
-            <div className="text-gray-400">
-              Last Updated: {new Date().toLocaleString()}
+          </div>
+
+          {/* Status Bar */}
+          <div className="mt-8 p-4 bg-gray-800 rounded-lg border border-gray-700">
+            <div className="flex flex-col gap-4 text-sm sm:text-base md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+                <div className="flex items-center">
+                  <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
+                  <span className="text-gray-300">Data Source: S3</span>
+                </div>
+                <div className="flex items-center">
+                  <div className="w-2 h-2 bg-blue-500 rounded-full mr-2"></div>
+                  <span className="text-gray-300">API Status: Active</span>
+                </div>
+              </div>
+              <div className="text-gray-400">
+                Last Updated: {new Date().toLocaleString()}
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </main>
+      </main>
     </Suspense>
   );
 }
-
 
 export default function DashboardPage() {
   return (

--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -194,7 +194,7 @@ export default function DataExplorerPage() {
       <main className="min-h-screen bg-gray-900 flex items-center justify-center">
         <div className="text-center">
           <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-gray-400">Loading ticker data...</p>
+          <p className="text-sm sm:text-base text-gray-400">Loading ticker data...</p>
         </div>
       </main>
     );
@@ -204,10 +204,10 @@ export default function DataExplorerPage() {
     return (
       <main className="min-h-screen bg-gray-900 flex items-center justify-center">
         <div className="text-center">
-          <p className="text-red-400 mb-4">Error: {error}</p>
+          <p className="text-sm sm:text-base text-red-400 mb-4">Error: {error}</p>
           <button
             onClick={() => window.location.reload()}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors"
+            className="px-5 py-3 sm:py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
           >
             Retry
           </button>
@@ -218,24 +218,24 @@ export default function DataExplorerPage() {
 
   return (
     <main className="min-h-screen bg-gray-900">
-      <div className="container mx-auto px-6 py-8">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
+        <div className="mb-8 space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-3 text-sm sm:text-base">
               <Link
                 href="/dashboard"
-                className="flex items-center text-gray-400 hover:text-white transition-colors"
+                className="inline-flex items-center text-gray-400 hover:text-white transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
               >
                 <ArrowLeft className="w-4 h-4 mr-1" />
                 Back to Dashboard
               </Link>
             </div>
 
-            <div className="flex space-x-3">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
               <Link
                 href="/backtester"
-                className="flex items-center px-4 py-2 border border-gray-600 text-gray-300 hover:text-white hover:border-gray-500 rounded-lg transition-colors"
+                className="inline-flex items-center justify-center px-4 py-3 sm:py-2 border border-gray-600 text-gray-300 hover:text-white hover:border-gray-500 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
               >
                 <TrendingUp className="w-4 h-4 mr-2" />
                 Backtester
@@ -243,19 +243,19 @@ export default function DataExplorerPage() {
             </div>
           </div>
 
-          <div className="mt-4">
-            <h1 className="text-3xl font-bold text-white mb-2">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-white">
               <Database className="inline w-8 h-8 mr-2 text-purple-400" />
               Data Explorer
             </h1>
-            <p className="text-gray-400 text-lg">
+            <p className="mt-2 text-sm sm:text-base text-gray-400">
               Explore available ticker datasets, metadata, and data coverage
             </p>
           </div>
         </div>
 
         {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
           <div className="bg-gray-800 rounded-lg p-4">
             <div className="flex items-center">
               <Database className="w-8 h-8 text-blue-400 mr-3" />
@@ -298,8 +298,8 @@ export default function DataExplorerPage() {
         </div>
 
         {/* Filters */}
-        <div className="bg-gray-800 rounded-lg p-6 mb-8">
-          <h3 className="text-lg font-semibold text-white mb-4">Filters & Search</h3>
+        <div className="bg-gray-800 rounded-lg p-5 sm:p-6 mb-8">
+          <h3 className="text-lg sm:text-xl font-semibold text-white mb-4">Filters & Search</h3>
 
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div>
@@ -340,9 +340,9 @@ export default function DataExplorerPage() {
               />
             </div>
 
-            <div>
+            <div className="flex flex-col sm:flex-row sm:items-end gap-2">
               <label className="block text-sm font-medium text-gray-300 mb-2">Sort By</label>
-              <div className="flex space-x-2">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                 <select
                   value={sortBy}
                   onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
@@ -354,7 +354,7 @@ export default function DataExplorerPage() {
                 </select>
                 <button
                   onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
-                  className="px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white hover:bg-gray-600 transition-colors"
+                  className="px-3 py-3 sm:py-2 bg-gray-700 border border-gray-600 rounded text-white hover:bg-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
                 >
                   {sortOrder === "asc" ? "↑" : "↓"}
                 </button>
@@ -366,12 +366,12 @@ export default function DataExplorerPage() {
         {/* Data Table */}
         <div className="bg-gray-800 rounded-lg overflow-hidden">
           <div className="p-4 border-b border-gray-700">
-            <h3 className="text-lg font-semibold text-white">
+            <h3 className="text-lg sm:text-xl font-semibold text-white">
               Ticker Catalog ({filteredTickers.length} items)
             </h3>
           </div>
 
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto scroll-container">
             <table className="w-full">
               <thead className="bg-gray-700">
                 <tr>
@@ -381,21 +381,21 @@ export default function DataExplorerPage() {
                   >
                     Ticker {sortBy === "ticker" && (sortOrder === "asc" ? "↑" : "↓")}
                   </th>
-                  <th className="text-left p-4 text-gray-300">Sector</th>
+                  <th className="text-left p-4 text-gray-300 hidden md:table-cell">Sector</th>
                   <th
                     className="text-right p-4 text-gray-300 cursor-pointer hover:text-white"
                     onClick={() => handleSort("records")}
                   >
                     Records {sortBy === "records" && (sortOrder === "asc" ? "↑" : "↓")}
                   </th>
-                  <th className="text-left p-4 text-gray-300">First Date</th>
+                  <th className="text-left p-4 text-gray-300 hidden sm:table-cell">First Date</th>
                   <th
                     className="text-left p-4 text-gray-300 cursor-pointer hover:text-white"
                     onClick={() => handleSort("lastDate")}
                   >
                     Last Date {sortBy === "lastDate" && (sortOrder === "asc" ? "↑" : "↓")}
                   </th>
-                  <th className="text-left p-4 text-gray-300">Format</th>
+                  <th className="text-left p-4 text-gray-300 hidden lg:table-cell">Format</th>
                   <th className="text-center p-4 text-gray-300">Actions</th>
                 </tr>
               </thead>
@@ -408,7 +408,7 @@ export default function DataExplorerPage() {
                         <div className="text-xs text-gray-400">{ticker.industry}</div>
                       )}
                     </td>
-                    <td className="p-4">
+                    <td className="p-4 hidden md:table-cell">
                       {ticker.sector ? (
                         <span className="inline-block px-2 py-1 bg-blue-600/20 text-blue-300 text-xs rounded">
                           {ticker.sector}
@@ -420,9 +420,9 @@ export default function DataExplorerPage() {
                     <td className="p-4 text-right text-gray-300">
                       {ticker.records != null ? ticker.records.toLocaleString() : "-"}
                     </td>
-                    <td className="p-4 text-gray-300">{ticker.firstDate ?? "-"}</td>
+                    <td className="p-4 text-gray-300 hidden sm:table-cell">{ticker.firstDate ?? "-"}</td>
                     <td className="p-4 text-gray-300">{ticker.lastDate ?? "-"}</td>
-                    <td className="p-4">
+                    <td className="p-4 hidden lg:table-cell">
                       {ticker.format && (
                         <span className="inline-block px-2 py-1 bg-green-600/20 text-green-300 text-xs rounded uppercase">
                           {ticker.format}
@@ -433,7 +433,7 @@ export default function DataExplorerPage() {
                       <div className="flex space-x-2 justify-center">
                         <Link
                           href={{ pathname: "/dashboard", query: { ticker: ticker.ticker } }}
-                          className="p-1 text-blue-400 hover:text-blue-300 transition-colors"
+                          className="inline-flex h-11 w-11 sm:h-9 sm:w-9 items-center justify-center rounded-full text-blue-400 hover:text-blue-300 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
                           title="View Chart"
                         >
                           <Eye className="w-4 h-4" />
@@ -443,7 +443,7 @@ export default function DataExplorerPage() {
                             href={ticker.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="p-1 text-gray-400 hover:text-gray-300 transition-colors"
+                            className="inline-flex h-11 w-11 sm:h-9 sm:w-9 items-center justify-center rounded-full text-gray-400 hover:text-gray-300 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
                             title="Download Data"
                           >
                             <Download className="w-4 h-4" />
@@ -457,7 +457,7 @@ export default function DataExplorerPage() {
             </table>
 
             {filteredTickers.length === 0 && (
-              <div className="p-8 text-center text-gray-400">
+              <div className="p-8 text-center text-sm sm:text-base text-gray-400">
                 No tickers match your current filters.
               </div>
             )}
@@ -467,14 +467,14 @@ export default function DataExplorerPage() {
         {/* Metadata */}
         {data?.asOf && (
           <div className="mt-8 p-4 bg-gray-800 rounded-lg border border-gray-700">
-            <div className="flex items-center justify-between text-sm">
-              <div className="flex items-center space-x-4">
+            <div className="flex flex-col gap-4 text-sm sm:text-base md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
                 <div className="flex items-center">
                   <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
                   <span className="text-gray-300">Data Source: {data.source || "S3"}</span>
                 </div>
               </div>
-              <div className="text-gray-400">
+              <div className="text-sm sm:text-base text-gray-400">
                 Last Updated: {new Date(data.asOf).toLocaleString()}
               </div>
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -43,3 +43,13 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background: #64748b;
 }
+
+html,
+body,
+#__next {
+  height: 100%;
+}
+
+.scroll-container {
+  -webkit-overflow-scrolling: touch;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
       <body className={inter.className}>{children}</body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,10 +4,13 @@ export const dynamic = 'force-dynamic'
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
-      <div className="text-center">
-        <h1 className="text-3xl font-bold text-white mb-4">AI Backtester</h1>
-        <Link href="/dashboard" className="px-4 py-2 border border-white/30 rounded-lg text-white/90 hover:text-white hover:border-white">
+    <main className="min-h-screen bg-gray-900 bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 flex min-h-screen flex-col items-center justify-center text-center space-y-6">
+        <h1 className="text-2xl sm:text-3xl font-bold text-white">AI Backtester</h1>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center justify-center px-5 py-3 sm:py-2.5 border border-white/30 rounded-lg text-white/90 hover:text-white hover:border-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+        >
           Open Dashboard
         </Link>
       </div>

--- a/app/strategy/page.tsx
+++ b/app/strategy/page.tsx
@@ -31,12 +31,39 @@ export default function StrategyPage() {
   };
 
   return (
-    <div className="p-8 text-white">
-      <h1 className="text-2xl font-bold">Strategy Lab</h1>
-      <textarea value={dsl} onChange={(e) => setDsl(e.target.value)} className="w-full h-64 text-black p-2 mt-4 rounded" />
-      <button onClick={run} className="mt-3 px-4 py-2 bg-blue-600 rounded">Run</button>
-      {err && <pre className="mt-4 text-red-400">{err}</pre>}
-      {result && <pre className="mt-4 whitespace-pre-wrap">{JSON.stringify(result, null, 2)}</pre>}
-    </div>
+    <main className="min-h-screen bg-gray-900 text-white">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+        <div className="max-w-3xl space-y-6">
+          <div className="space-y-2">
+            <h1 className="text-2xl sm:text-3xl font-bold">Strategy Lab</h1>
+            <p className="text-sm sm:text-base text-gray-300">
+              Quickly experiment with strategy DSL payloads and view raw execution responses.
+            </p>
+          </div>
+
+          <textarea
+            value={dsl}
+            onChange={(e) => setDsl(e.target.value)}
+            className="w-full min-h-[16rem] rounded bg-gray-800 text-gray-100 p-4 text-sm sm:text-base border border-gray-700 focus:outline-none focus:border-blue-500"
+          />
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+            <button
+              onClick={run}
+              className="px-5 py-3 sm:py-2 bg-blue-600 hover:bg-blue-700 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+            >
+              Run
+            </button>
+          </div>
+          {err && (
+            <pre className="text-sm text-red-400 whitespace-pre-wrap">{err}</pre>
+          )}
+          {result && (
+            <pre className="whitespace-pre-wrap bg-gray-800 border border-gray-700 rounded p-4 text-sm sm:text-base">
+              {JSON.stringify(result, null, 2)}
+            </pre>
+          )}
+        </div>
+      </div>
+    </main>
   );
 }

--- a/components/backtest-results.tsx
+++ b/components/backtest-results.tsx
@@ -50,7 +50,7 @@ export function BacktestResults({ results, generatedStrategy }: BacktestResultsP
     <div className="space-y-6">
       {/* Generated Strategy Display */}
       {generatedStrategy && (
-        <div className="bg-gray-800 rounded-lg p-6">
+        <div className="bg-gray-800 rounded-lg p-4 sm:p-6">
           <h3 className="text-lg font-semibold text-white mb-4">
             Generated {generatedStrategy.mode === "dsl" ? "Strategy DSL" : "Python Code"}
           </h3>
@@ -76,10 +76,10 @@ export function BacktestResults({ results, generatedStrategy }: BacktestResultsP
       )}
 
       {/* Summary Stats */}
-      <div className="bg-gray-800 rounded-lg p-6">
+      <div className="bg-gray-800 rounded-lg p-4 sm:p-6">
         <h3 className="text-lg font-semibold text-white mb-4">Backtest Summary</h3>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
           <div className="text-center p-4 bg-gray-700 rounded">
             <div className="text-2xl font-bold text-blue-400">{summary.processedTickers}</div>
             <div className="text-sm text-gray-400">Tickers Processed</div>
@@ -123,7 +123,7 @@ export function BacktestResults({ results, generatedStrategy }: BacktestResultsP
 
       {/* Per-Ticker Results */}
       {perTicker.map((result, index) => (
-        <div key={index} className="bg-gray-800 rounded-lg p-6">
+        <div key={index} className="bg-gray-800 rounded-lg p-4 sm:p-6">
           <h3 className="text-lg font-semibold text-white mb-4">
             {result.ticker} Results
           </h3>
@@ -131,7 +131,7 @@ export function BacktestResults({ results, generatedStrategy }: BacktestResultsP
           {result.mode === "dsl" && result.stats && (
             <>
               {/* DSL Results */}
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
                 <div className="flex items-center p-3 bg-gray-700 rounded">
                   <TrendingUp className="w-8 h-8 text-green-400 mr-3" />
                   <div>

--- a/components/price-chart.tsx
+++ b/components/price-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { PriceLineChart } from "./ui/chart";
 
 interface PriceData {
@@ -24,6 +24,8 @@ export function PriceChart({ ticker }: PriceChartProps) {
     start: "",
     end: ""
   });
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [resizeKey, setResizeKey] = useState(0);
 
   useEffect(() => {
     if (!ticker) return;
@@ -56,16 +58,33 @@ export function PriceChart({ ticker }: PriceChartProps) {
     loadPriceData();
   }, [ticker, dateRange.start, dateRange.end]);
 
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      setResizeKey((prev) => prev + 1);
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
   const latestPrice = data.length > 0 ? data[data.length - 1] : null;
 
   return (
-    <div className="bg-gray-800 rounded-lg p-4">
-      <div className="flex justify-between items-center mb-4">
+    <div className="bg-gray-800 rounded-lg p-4 sm:p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
         <h3 className="text-lg font-semibold text-white">
           {ticker} Price Chart
         </h3>
         {latestPrice && (
-          <div className="text-right">
+          <div className="text-left sm:text-right">
             <div className="text-xl font-bold text-white">
               ${latestPrice.close.toFixed(2)}
             </div>
@@ -76,8 +95,8 @@ export function PriceChart({ ticker }: PriceChartProps) {
         )}
       </div>
 
-      <div className="flex gap-4 mb-4">
-        <div>
+      <div className="flex flex-col sm:flex-row sm:items-end gap-4 mb-4">
+        <div className="flex-1 sm:flex-none">
           <label className="block text-sm text-gray-400 mb-1">Start Date</label>
           <input
             type="date"
@@ -86,7 +105,7 @@ export function PriceChart({ ticker }: PriceChartProps) {
             className="px-3 py-1 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
           />
         </div>
-        <div>
+        <div className="flex-1 sm:flex-none">
           <label className="block text-sm text-gray-400 mb-1">End Date</label>
           <input
             type="date"
@@ -99,22 +118,24 @@ export function PriceChart({ ticker }: PriceChartProps) {
 
       {loading && (
         <div className="h-64 flex items-center justify-center border rounded bg-gray-900">
-          <p className="text-gray-400">Loading chart data...</p>
+          <p className="text-sm sm:text-base text-gray-400">Loading chart data...</p>
         </div>
       )}
 
       {error && (
         <div className="h-64 flex items-center justify-center border rounded bg-red-900/20">
-          <p className="text-red-400">Error: {error}</p>
+          <p className="text-sm sm:text-base text-red-400">Error: {error}</p>
         </div>
       )}
 
       {!loading && !error && data.length > 0 && (
-        <>
-          <PriceLineChart data={data} />
+        <div className="w-full space-y-4">
+          <div className="w-full" ref={containerRef} style={{ aspectRatio: "16/9" }}>
+            <PriceLineChart key={resizeKey} data={data} />
+          </div>
 
           {latestPrice && (
-            <div className="mt-4 grid grid-cols-2 md:grid-cols-4 gap-4 p-4 bg-gray-700 rounded">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 p-4 bg-gray-700 rounded">
               <div>
                 <div className="text-xs text-gray-400">Open</div>
                 <div className="text-white font-medium">${latestPrice.open.toFixed(2)}</div>
@@ -133,12 +154,12 @@ export function PriceChart({ ticker }: PriceChartProps) {
               </div>
             </div>
           )}
-        </>
+        </div>
       )}
 
       {!loading && !error && data.length === 0 && (
         <div className="h-64 flex items-center justify-center border rounded bg-gray-900">
-          <p className="text-gray-400">No data available for {ticker}</p>
+          <p className="text-sm sm:text-base text-gray-400">No data available for {ticker}</p>
         </div>
       )}
     </div>

--- a/components/strategy-form.tsx
+++ b/components/strategy-form.tsx
@@ -53,7 +53,7 @@ export function StrategyForm({ onRunStrategy, loading }: StrategyFormProps) {
   };
 
   return (
-    <div className="bg-gray-800 rounded-lg p-6">
+    <div className="bg-gray-800 rounded-lg p-4 sm:p-6">
       <div className="mb-6">
         <h2 className="text-xl font-semibold text-white mb-2">Strategy Builder</h2>
         <p className="text-gray-400">
@@ -65,11 +65,11 @@ export function StrategyForm({ onRunStrategy, loading }: StrategyFormProps) {
         {/* Mode Selection */}
         <div>
           <label className="block text-sm font-medium text-gray-300 mb-3">Strategy Type</label>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <button
               type="button"
               onClick={() => setMode("dsl")}
-              className={`p-4 rounded-lg border text-left transition-colors ${
+              className={`p-4 rounded-lg border text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 ${
                 mode === "dsl"
                   ? "border-blue-500 bg-blue-500/10 text-white"
                   : "border-gray-600 bg-gray-700 text-gray-300 hover:border-gray-500"
@@ -87,7 +87,7 @@ export function StrategyForm({ onRunStrategy, loading }: StrategyFormProps) {
             <button
               type="button"
               onClick={() => setMode("ml")}
-              className={`p-4 rounded-lg border text-left transition-colors ${
+              className={`p-4 rounded-lg border text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800 ${
                 mode === "ml"
                   ? "border-purple-500 bg-purple-500/10 text-white"
                   : "border-gray-600 bg-gray-700 text-gray-300 hover:border-gray-500"
@@ -127,7 +127,7 @@ export function StrategyForm({ onRunStrategy, loading }: StrategyFormProps) {
                   key={index}
                   type="button"
                   onClick={() => setPrompt(example)}
-                  className="block w-full text-left text-xs text-blue-400 hover:text-blue-300 transition-colors"
+                  className="block w-full text-left text-xs text-blue-400 hover:text-blue-300 transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
                 >
                   • {example}
                 </button>
@@ -137,7 +137,7 @@ export function StrategyForm({ onRunStrategy, loading }: StrategyFormProps) {
         </div>
 
         {/* Test Parameters */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-300 mb-2">
               Tickers (comma-separated)
@@ -179,7 +179,7 @@ export function StrategyForm({ onRunStrategy, loading }: StrategyFormProps) {
         <button
           type="submit"
           disabled={loading || !prompt.trim()}
-          className="w-full flex items-center justify-center px-6 py-3 bg-green-600 hover:bg-green-700 disabled:bg-gray-600 text-white font-medium rounded-lg transition-colors"
+          className="w-full flex items-center justify-center px-6 py-3 bg-green-600 hover:bg-green-700 disabled:bg-gray-600 text-white font-medium rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
         >
           {loading ? (
             <>

--- a/components/ticker-selector.tsx
+++ b/components/ticker-selector.tsx
@@ -65,8 +65,8 @@ export function TickerSelector({ onTickerSelect, selectedTicker }: TickerSelecto
   }
 
   return (
-    <div className="bg-gray-800 rounded-lg p-4">
-      <h3 className="text-lg font-semibold text-white mb-3">
+    <div className="bg-gray-800 rounded-lg p-4 space-y-4">
+      <h3 className="text-lg sm:text-xl font-semibold text-white">
         Available Tickers ({tickers.length})
       </h3>
 
@@ -75,34 +75,34 @@ export function TickerSelector({ onTickerSelect, selectedTicker }: TickerSelecto
         placeholder="Search tickers..."
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        className="w-full px-3 py-2 mb-3 bg-gray-700 border border-gray-600 rounded text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
+        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white placeholder-gray-400 text-base sm:text-sm focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
       />
 
       <div className="max-h-64 overflow-y-auto">
         {filteredTickers.length === 0 ? (
           <p className="text-gray-400">No tickers found</p>
         ) : (
-          <div className="space-y-1">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {filteredTickers.map((ticker) => (
               <button
                 key={ticker.ticker}
                 onClick={() => onTickerSelect(ticker.ticker)}
-                className={`w-full text-left px-3 py-2 rounded transition-colors ${
+                className={`w-full text-left px-3 py-3 sm:py-2 rounded transition-colors text-sm sm:text-base focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                   selectedTicker === ticker.ticker
                     ? "bg-blue-600 text-white"
                     : "bg-gray-700 text-gray-200 hover:bg-gray-600"
                 }`}
               >
-                <div className="flex justify-between items-center">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                   <span className="font-medium">{ticker.ticker}</span>
                   {ticker.records && (
-                    <span className="text-xs text-gray-400">
+                    <span className="text-xs sm:text-sm text-gray-400">
                       {ticker.records.toLocaleString()} records
                     </span>
                   )}
                 </div>
                 {ticker.lastDate && (
-                  <div className="text-xs text-gray-400 mt-1">
+                  <div className="text-xs sm:text-sm text-gray-400 mt-1">
                     Latest: {ticker.lastDate}
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- add a mobile-friendly viewport meta tag and touch scrolling helpers so the app lays out predictably on phones
- unify page containers, typography, and dashboards around responsive grid behavior and ticker selection updates that prioritize the chart on small screens
- rework the data explorer table with horizontal scroll, column hiding, and actionable controls sized for touch while making the price chart responsive with a resize observer
- increase tap targets and add focus-visible outlines across navigation links, quick actions, and strategy form controls

## Testing
- npm run lint *(fails: Next.js CLI prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d34794fcf0832ba3dc3d1a27159c84