### PR TITLE
Dashboard multi-select, indicators; Strategy ticker validation; deep-link & date limits

### DIFF
--- a/app/strategy/page.tsx
+++ b/app/strategy/page.tsx
@@ -1,67 +1,422 @@
 "use client";
-import { useState } from "react";
 
-const DEFAULT_DSL = `{
-  "tickers": ["AAPL","MSFT"],
-  "rules": [
-    {"type":"sma","length":10,"field":"close","alias":"sma10"},
-    {"type":"cross","fast":"close","slow":"sma10","enter":"fast_above","exit":"fast_below"}
-  ],
-  "capital": 100000
-}`;
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { NotificationBar } from "@/components/notifications";
+import { getTickerMeta, intersectRange } from "@/lib/useDateLimits";
+import { buildSamplePromptFromKeys } from "@/lib/samplePrompt";
+
+function parseTickers(input: string): string[] {
+  return input
+    .split(/[\s,]+/)
+    .map((value) => value.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+const DEFAULT_PROMPT =
+  "Design a swing trading strategy that uses SMA(20) crossovers with RSI confirmation and risk controls.";
 
 export default function StrategyPage() {
-  const [dsl, setDsl] = useState(DEFAULT_DSL);
+  const [tickersInput, setTickersInput] = useState("AAPL, MSFT");
+  const [dateRange, setDateRange] = useState<{ start?: string; end?: string }>({});
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
+  const [dslText, setDslText] = useState<string>("");
   const [result, setResult] = useState<any>(null);
-  const [err, setErr] = useState("");
+  const [logs, setLogs] = useState<string[]>([]);
+  const [notification, setNotification] = useState<{ message: string; tone?: "info" | "warning" | "success" | "error" } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [limits, setLimits] = useState<{ min?: string; max?: string }>({});
+  const [limitMessage, setLimitMessage] = useState<string | null>(null);
+  const [prefillApplied, setPrefillApplied] = useState(false);
 
-  const run = async () => {
-    setErr("");
+  const searchParams = useSearchParams();
+
+  const activeTickers = useMemo(() => parseTickers(tickersInput), [tickersInput]);
+  const activeTickersKey = useMemo(() => activeTickers.join(","), [activeTickers]);
+
+  useEffect(() => {
+    if (prefillApplied) return;
+    if (!searchParams || searchParams.get("prefill") !== "1") return;
+
+    const tickersParam = searchParams.get("tickers") ?? "";
+    const startParam = searchParams.get("start") ?? undefined;
+    const endParam = searchParams.get("end") ?? undefined;
+    const promptParam = searchParams.get("prompt") ?? undefined;
+    const indicatorsParam = searchParams.get("indicators") ?? undefined;
+
+    if (tickersParam) {
+      setTickersInput(tickersParam);
+    }
+    if (startParam || endParam) {
+      setDateRange((prev) => ({
+        start: startParam || prev.start,
+        end: endParam || prev.end,
+      }));
+    }
+
+    if (promptParam) {
+      setPrompt(promptParam);
+    } else if (indicatorsParam) {
+      const sample = buildSamplePromptFromKeys(
+        indicatorsParam.split(","),
+        tickersParam ? parseTickers(tickersParam) : [],
+        startParam,
+        endParam,
+      );
+      if (sample) setPrompt(sample);
+    }
+
+    setNotification({ tone: "info", message: "Pre-filled from Dashboard." });
+    setPrefillApplied(true);
+  }, [searchParams, prefillApplied]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!activeTickers.length) {
+      setLimits({});
+      setLimitMessage(null);
+      return;
+    }
+
+    (async () => {
+      const meta = await getTickerMeta();
+      if (cancelled) return;
+
+      const nextLimits = intersectRange(activeTickers, meta);
+      setLimits(nextLimits);
+
+      if (nextLimits.min && nextLimits.max && nextLimits.min > nextLimits.max) {
+        setLimitMessage("No overlapping date range for the selected tickers.");
+        if (dateRange.start || dateRange.end) {
+          setDateRange({});
+        }
+        return;
+      }
+
+      let start = dateRange.start;
+      let end = dateRange.end;
+      let clamped = false;
+
+      if (nextLimits.min && start && start < nextLimits.min) {
+        start = nextLimits.min;
+        clamped = true;
+      }
+      if (nextLimits.max && end && end > nextLimits.max) {
+        end = nextLimits.max;
+        clamped = true;
+      }
+      if (nextLimits.min && nextLimits.max && start && end && start > nextLimits.max) {
+        start = nextLimits.min;
+        end = nextLimits.max;
+        clamped = true;
+      }
+
+      if (start !== dateRange.start || end !== dateRange.end) {
+        setDateRange({ start, end });
+      }
+
+      if (clamped && (nextLimits.min || nextLimits.max)) {
+        const minLabel = nextLimits.min ?? "earliest";
+        const maxLabel = nextLimits.max ?? "latest";
+        setLimitMessage(`Dates limited to available range across selected tickers: ${minLabel} → ${maxLabel}.`);
+      } else {
+        setLimitMessage(null);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTickersKey]);
+
+  const limitValid = !limits.min || !limits.max || limits.min <= limits.max;
+
+  const handleStartChange = (value: string) => {
+    let next = value ? value : undefined;
+    if (next && limits.min && next < limits.min) {
+      next = limits.min;
+    }
+    if (limitValid && next && limits.max && next > limits.max) {
+      next = limits.max;
+    }
+
+    let end = dateRange.end;
+    if (next && end && end < next) {
+      end = next;
+    }
+    setDateRange({ start: next, end });
+  };
+
+  const handleEndChange = (value: string) => {
+    let next = value ? value : undefined;
+    if (limitValid && next && limits.max && next > limits.max) {
+      next = limits.max;
+    }
+    if (next && limits.min && next < limits.min) {
+      next = limits.min;
+    }
+
+    let start = dateRange.start;
+    if (start && next && start > next) {
+      start = next;
+    }
+    setDateRange({ start, end: next });
+  };
+
+  const runBacktest = async () => {
+    setError(null);
+    setNotification(null);
+    setLogs([]);
+
+    const parsed = parseTickers(tickersInput);
+    if (!parsed.length) {
+      setError("Please provide at least one ticker symbol.");
+      return;
+    }
+    if (!prompt.trim()) {
+      setError("Please describe the strategy you want to generate.");
+      return;
+    }
+
+    setIsSubmitting(true);
     try {
-      const res = await fetch("/api/strategy/run", {
+      const meta = await getTickerMeta();
+      const available = new Set(Object.keys(meta));
+      const validTickers = parsed.filter((ticker) => available.has(ticker));
+      const invalidTickers = parsed.filter((ticker) => !available.has(ticker));
+
+      if (invalidTickers.length) {
+        if (!validTickers.length) {
+          setNotification({
+            tone: "error",
+            message: `Removed unavailable tickers: ${invalidTickers.join(", ")}. No valid tickers remain.`,
+          });
+          setTickersInput("");
+          setIsSubmitting(false);
+          return;
+        }
+        setNotification({
+          tone: "warning",
+          message: `Removed unavailable tickers: ${invalidTickers.join(", ")}. Continuing with: ${validTickers.join(", ")}.`,
+        });
+        setTickersInput(validTickers.join(", "));
+      }
+
+      const workingTickers = validTickers.length ? validTickers : parsed;
+      const workingLimits = intersectRange(workingTickers, meta);
+      if (workingLimits.min && workingLimits.max && workingLimits.min > workingLimits.max) {
+        setError("No overlapping history for the selected tickers.");
+        setIsSubmitting(false);
+        return;
+      }
+
+      const startDate = dateRange.start ?? workingLimits.min ?? limits.min;
+      const endDate = dateRange.end ?? workingLimits.max ?? limits.max;
+
+      const generateResponse = await fetch("/api/strategy/generate", {
         method: "POST",
-        headers: { "content-type": "application/json" },
-        body: dsl,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt }),
       });
-      const j = await res.json();
-      setResult(j);
-    } catch (e: any) {
-      setErr(String(e));
+      const generated = await generateResponse.json();
+      if (!generateResponse.ok || !generated.ok) {
+        throw new Error(generated.error || "Failed to generate strategy definition");
+      }
+      setDslText(JSON.stringify(generated.dsl, null, 2));
+
+      const runResponse = await fetch("/api/strategy/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tickers: workingTickers,
+          startDate,
+          endDate,
+          dsl: generated.dsl,
+        }),
+      });
+      const runJson = await runResponse.json();
+      if (!runResponse.ok || !runJson.ok) {
+        throw new Error(runJson.error || "Strategy backtest failed");
+      }
+
+      setResult(runJson);
+      setLogs(runJson.logs ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   return (
     <main className="min-h-screen bg-gray-900 text-white">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-        <div className="max-w-3xl space-y-6">
-          <div className="space-y-2">
-            <h1 className="text-2xl sm:text-3xl font-bold">Strategy Lab</h1>
-            <p className="text-sm sm:text-base text-gray-300">
-              Quickly experiment with strategy DSL payloads and view raw execution responses.
-            </p>
-          </div>
+        <div className="mb-8 space-y-2">
+          <h1 className="text-2xl sm:text-3xl font-bold">Strategy Lab</h1>
+          <p className="text-sm sm:text-base text-gray-300">
+            Generate a rules-based trading strategy with AI, validate tickers, and run a quick historical backtest.
+          </p>
+        </div>
 
-          <textarea
-            value={dsl}
-            onChange={(e) => setDsl(e.target.value)}
-            className="w-full min-h-[16rem] rounded bg-gray-800 text-gray-100 p-4 text-sm sm:text-base border border-gray-700 focus:outline-none focus:border-blue-500"
-          />
-          <div className="flex flex-col sm:flex-row sm:items-center gap-3">
-            <button
-              onClick={run}
-              className="px-5 py-3 sm:py-2 bg-blue-600 hover:bg-blue-700 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
-            >
-              Run
-            </button>
-          </div>
-          {err && (
-            <pre className="text-sm text-red-400 whitespace-pre-wrap">{err}</pre>
+        <div className="space-y-4">
+          {notification && (
+            <NotificationBar
+              message={notification.message}
+              tone={notification.tone}
+              onDismiss={() => setNotification(null)}
+            />
           )}
-          {result && (
-            <pre className="whitespace-pre-wrap bg-gray-800 border border-gray-700 rounded p-4 text-sm sm:text-base">
-              {JSON.stringify(result, null, 2)}
-            </pre>
+          {error && (
+            <NotificationBar message={error} tone="error" onDismiss={() => setError(null)} />
           )}
+        </div>
+
+        <div className="mt-6 grid gap-6 lg:grid-cols-5">
+          <section className="space-y-4 lg:col-span-3 min-w-0">
+            <div className="space-y-5 rounded-lg border border-gray-700 bg-gray-800/70 p-4 sm:p-6">
+              <div>
+                <label className="block text-sm font-semibold text-gray-200">Tickers</label>
+                <textarea
+                  value={tickersInput}
+                  onChange={(event) => setTickersInput(event.target.value)}
+                  placeholder="AAPL, MSFT, NVDA"
+                  className="mt-2 w-full min-h-[5rem] rounded border border-gray-600 bg-gray-900 px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <p className="mt-1 text-xs text-gray-400">Separate with commas, spaces, or new lines.</p>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div>
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
+                    Start Date
+                  </label>
+                  <input
+                    type="date"
+                    value={dateRange.start ?? ""}
+                    min={limits.min}
+                    max={limitValid ? limits.max : undefined}
+                    onChange={(event) => handleStartChange(event.target.value)}
+                    className="w-full rounded border border-gray-600 bg-gray-900 px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
+                    End Date
+                  </label>
+                  <input
+                    type="date"
+                    value={dateRange.end ?? ""}
+                    min={limits.min}
+                    max={limitValid ? limits.max : undefined}
+                    onChange={(event) => handleEndChange(event.target.value)}
+                    className="w-full rounded border border-gray-600 bg-gray-900 px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+              </div>
+
+              {limitMessage && (
+                <p className="text-xs text-amber-300">{limitMessage}</p>
+              )}
+
+              <div>
+                <label className="block text-sm font-semibold text-gray-200">Strategy prompt</label>
+                <textarea
+                  value={prompt}
+                  onChange={(event) => setPrompt(event.target.value)}
+                  className="mt-2 w-full min-h-[10rem] rounded border border-gray-600 bg-gray-900 px-3 py-3 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <button
+                  type="button"
+                  onClick={runBacktest}
+                  disabled={isSubmitting}
+                  className="inline-flex items-center justify-center rounded bg-blue-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-600/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                >
+                  {isSubmitting ? "Running…" : "Generate & Run"}
+                </button>
+                <p className="text-xs text-gray-400">
+                  The lab will validate your tickers, generate a DSL strategy, and execute a quick historical simulation.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4 lg:col-span-2 min-w-0">
+            {dslText && (
+              <div className="rounded-lg border border-gray-700 bg-gray-800/80 p-4">
+                <h3 className="text-sm font-semibold text-gray-200">Generated Strategy DSL</h3>
+                <pre className="mt-3 max-h-72 overflow-auto rounded bg-gray-900/70 p-3 text-xs text-gray-100">
+                  {dslText}
+                </pre>
+              </div>
+            )}
+
+            {result?.summary && (
+              <div className="rounded-lg border border-gray-700 bg-gray-800/80 p-4 space-y-3">
+                <h3 className="text-sm font-semibold text-gray-200">Backtest Summary</h3>
+                <div className="grid grid-cols-2 gap-3 text-sm text-gray-200">
+                  <div>
+                    <div className="text-xs uppercase text-gray-400">Processed</div>
+                    <div>{result.summary.processedTickers}/{result.summary.requestedTickers}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase text-gray-400">Avg Return</div>
+                    <div>{result.summary.avgReturnPct?.toFixed?.(2) ?? "0.00"}%</div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase text-gray-400">Trades</div>
+                    <div>{result.summary.totalTrades ?? 0}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase text-gray-400">Range</div>
+                    <div>
+                      {result.summary.startDate} → {result.summary.endDate}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {Array.isArray(result?.perTicker) && result.perTicker.length > 0 && (
+              <div className="rounded-lg border border-gray-700 bg-gray-800/80 p-4 space-y-3">
+                <h3 className="text-sm font-semibold text-gray-200">Per-ticker performance</h3>
+                <div className="space-y-2 text-xs text-gray-200">
+                  {result.perTicker.map((entry: any) => (
+                    <div
+                      key={entry.ticker}
+                      className="flex items-center justify-between rounded border border-gray-700 bg-gray-900/60 px-3 py-2"
+                    >
+                      <span className="font-semibold text-white">{entry.ticker}</span>
+                      {entry.stats ? (
+                        <span className="text-emerald-400">
+                          {entry.stats.totalReturnPct?.toFixed?.(2) ?? "0.00"}% return · {entry.stats.trades ?? 0} trades
+                        </span>
+                      ) : (
+                        <span className="text-gray-400">No trades</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {logs.length > 0 && (
+              <div className="rounded-lg border border-gray-700 bg-gray-800/80 p-4">
+                <h3 className="text-sm font-semibold text-gray-200">Execution logs</h3>
+                <ul className="mt-2 space-y-1 text-xs text-gray-300">
+                  {logs.map((log, index) => (
+                    <li key={index} className="rounded bg-gray-900/60 px-2 py-1">
+                      {log}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
         </div>
       </div>
     </main>

--- a/components/IndicatorToggles.tsx
+++ b/components/IndicatorToggles.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import clsx from "clsx";
+
+interface IndicatorState {
+  rsi: boolean;
+  macd: boolean;
+  sma: boolean;
+  ema: boolean;
+}
+
+interface IndicatorTogglesProps {
+  value: IndicatorState;
+  onChange: (value: IndicatorState) => void;
+}
+
+const INDICATOR_CONFIG: Array<{ key: keyof IndicatorState; label: string; description: string }> = [
+  { key: "sma", label: "SMA (20)", description: "Simple moving average" },
+  { key: "ema", label: "EMA (50)", description: "Exponential moving average" },
+  { key: "rsi", label: "RSI (14)", description: "Momentum oscillator" },
+  { key: "macd", label: "MACD", description: "Trend & momentum" },
+];
+
+export function IndicatorToggles({ value, onChange }: IndicatorTogglesProps) {
+  const toggle = (key: keyof IndicatorState) => {
+    onChange({ ...value, [key]: !value[key] });
+  };
+
+  return (
+    <aside className="flex flex-col gap-3 rounded-lg border border-gray-700 bg-gray-800/80 p-4 text-sm text-gray-300 shadow-sm">
+      <h3 className="text-base font-semibold text-white">Indicators</h3>
+      <p className="text-xs text-gray-400">
+        Choose overlays and oscillators to display alongside price series.
+      </p>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {INDICATOR_CONFIG.map((indicator) => {
+          const active = value[indicator.key];
+          return (
+            <button
+              key={indicator.key}
+              type="button"
+              aria-pressed={active}
+              onClick={() => toggle(indicator.key)}
+              className={clsx(
+                "flex flex-col items-start gap-1 rounded-md border px-3 py-2 text-left transition",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900",
+                active
+                  ? "border-blue-500 bg-blue-600/30 text-white shadow-inner"
+                  : "border-gray-600 bg-gray-900/60 text-gray-200 hover:border-gray-500 hover:bg-gray-700/70"
+              )}
+            >
+              <span className="text-sm font-medium tracking-wide">{indicator.label}</span>
+              <span className="text-xs text-gray-400">{indicator.description}</span>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/components/indicators.ts
+++ b/components/indicators.ts
@@ -1,0 +1,119 @@
+export function sma(series: number[], period: number): Array<number | null> {
+  if (!Array.isArray(series) || period <= 0) return [];
+  const result: Array<number | null> = new Array(series.length).fill(null);
+
+  for (let index = period - 1; index < series.length; index++) {
+    const window = series.slice(index - period + 1, index + 1);
+    if (window.some((value) => !Number.isFinite(value))) {
+      continue;
+    }
+    const sum = window.reduce((accumulator, value) => accumulator + value, 0);
+    result[index] = sum / period;
+  }
+
+  return result;
+}
+
+export function ema(series: Array<number | null | undefined>, period: number): Array<number | null> {
+  if (!Array.isArray(series) || period <= 0) return [];
+  const normalized = series.map((value) =>
+    typeof value === "number" && Number.isFinite(value) ? value : null,
+  );
+  const result: Array<number | null> = new Array(series.length).fill(null);
+  const multiplier = 2 / (period + 1);
+  let previous: number | null = null;
+  let window: number[] = [];
+
+  for (let index = 0; index < normalized.length; index++) {
+    const value = normalized[index];
+    if (value == null) {
+      previous = null;
+      window = [];
+      result[index] = null;
+      continue;
+    }
+
+    window.push(value);
+    if (window.length > period) {
+      window.shift();
+    }
+
+    if (previous == null) {
+      if (window.length < period) {
+        result[index] = null;
+        continue;
+      }
+      const sum = window.reduce((accumulator, val) => accumulator + val, 0);
+      previous = sum / period;
+      result[index] = previous;
+      continue;
+    }
+
+    previous = (value - previous) * multiplier + previous;
+    result[index] = previous;
+  }
+
+  return result;
+}
+
+export function rsi(series: number[], period = 14): Array<number | null> {
+  if (!Array.isArray(series) || series.length === 0 || period <= 0) return [];
+  const result: Array<number | null> = new Array(series.length).fill(null);
+  let avgGain = 0;
+  let avgLoss = 0;
+
+  for (let index = 1; index < series.length; index++) {
+    const change = series[index] - series[index - 1];
+    const gain = change > 0 ? change : 0;
+    const loss = change < 0 ? -change : 0;
+
+    if (index <= period) {
+      avgGain += gain;
+      avgLoss += loss;
+      if (index === period) {
+        avgGain /= period;
+        avgLoss /= period;
+        const rs = avgLoss === 0 ? Number.POSITIVE_INFINITY : avgGain / avgLoss;
+        result[index] = avgLoss === 0 ? 100 : 100 - 100 / (1 + rs);
+      }
+      continue;
+    }
+
+    avgGain = (avgGain * (period - 1) + gain) / period;
+    avgLoss = (avgLoss * (period - 1) + loss) / period;
+
+    const rs = avgLoss === 0 ? Number.POSITIVE_INFINITY : avgGain / avgLoss;
+    result[index] = avgLoss === 0 ? 100 : 100 - 100 / (1 + rs);
+  }
+
+  return result;
+}
+
+export function macd(
+  series: number[],
+  fast = 12,
+  slow = 26,
+  signal = 9,
+): { macd: Array<number | null>; signal: Array<number | null>; hist: Array<number | null> } {
+  if (!Array.isArray(series) || series.length === 0) {
+    return { macd: [], signal: [], hist: [] };
+  }
+
+  const fastEma = ema(series, fast);
+  const slowEma = ema(series, slow);
+  const macdLine = series.map((_, index) => {
+    const fastValue = fastEma[index];
+    const slowValue = slowEma[index];
+    if (fastValue == null || slowValue == null) return null;
+    return fastValue - slowValue;
+  });
+
+  const signalLine = ema(macdLine, signal);
+  const histogram = macdLine.map((value, index) => {
+    const signalValue = signalLine[index];
+    if (value == null || signalValue == null) return null;
+    return value - signalValue;
+  });
+
+  return { macd: macdLine, signal: signalLine, hist: histogram };
+}

--- a/components/notifications.tsx
+++ b/components/notifications.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import clsx from "clsx";
+
+interface NotificationBarProps {
+  message: string;
+  tone?: "info" | "warning" | "success" | "error";
+  onDismiss?: () => void;
+}
+
+const toneStyles: Record<Required<NotificationBarProps>["tone"], string> = {
+  info: "border-blue-500/40 bg-blue-900/30 text-blue-100",
+  warning: "border-amber-500/40 bg-amber-900/30 text-amber-100",
+  success: "border-emerald-500/40 bg-emerald-900/30 text-emerald-100",
+  error: "border-red-500/40 bg-red-900/30 text-red-100",
+};
+
+export function NotificationBar({ message, tone = "info", onDismiss }: NotificationBarProps) {
+  return (
+    <div
+      className={clsx(
+        "flex flex-wrap items-start justify-between gap-3 rounded-md border px-4 py-3 text-sm",
+        toneStyles[tone],
+      )}
+      role="status"
+    >
+      <span className="flex-1 leading-5">{message}</span>
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="rounded bg-black/10 px-2 py-1 text-xs font-medium uppercase tracking-wide text-white/80 transition hover:bg-black/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 focus-visible:ring-white/70"
+        >
+          Dismiss
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/price-chart.tsx
+++ b/components/price-chart.tsx
@@ -1,9 +1,20 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { PriceLineChart } from "./ui/chart";
+import { useEffect, useMemo, useState } from "react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ReferenceLine,
+} from "recharts";
+import { ema, macd, rsi, sma } from "./indicators";
 
-interface PriceData {
+interface PriceRow {
   date: string;
   open: number;
   high: number;
@@ -13,153 +24,504 @@ interface PriceData {
 }
 
 interface PriceChartProps {
-  ticker: string;
+  tickers: string[];
+  dateRange?: { start?: string; end?: string };
+  indicators?: { rsi?: boolean; macd?: boolean; sma?: boolean; ema?: boolean };
 }
 
-export function PriceChart({ ticker }: PriceChartProps) {
-  const [data, setData] = useState<PriceData[]>([]);
+interface ChartPoint {
+  date: string;
+  [key: string]: string | number | null | undefined;
+}
+
+const SERIES_COLORS = [
+  "#60A5FA",
+  "#F97316",
+  "#34D399",
+  "#F472B6",
+  "#A855F7",
+  "#FACC15",
+  "#38BDF8",
+  "#F87171",
+];
+
+const PRICE_TOOLTIP_STYLE = {
+  backgroundColor: "#1F2937",
+  border: "1px solid #374151",
+  borderRadius: "8px",
+  color: "#F9FAFB",
+  fontSize: "0.875rem",
+};
+
+const LABEL_DATE_FORMATTER = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString();
+};
+
+export function PriceChart({ tickers, dateRange, indicators }: PriceChartProps) {
+  const indicatorState = useMemo(
+    () => ({
+      rsi: indicators?.rsi ?? false,
+      macd: indicators?.macd ?? false,
+      sma: indicators?.sma ?? false,
+      ema: indicators?.ema ?? false,
+    }),
+    [indicators],
+  );
+  const normalizedTickers = useMemo(
+    () =>
+      Array.from(new Set(tickers.map((ticker) => ticker.toUpperCase()))).filter(
+        Boolean,
+      ),
+    [tickers],
+  );
+
+  const [seriesMap, setSeriesMap] = useState<Record<string, PriceRow[]>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [dateRange, setDateRange] = useState({
-    start: "",
-    end: ""
-  });
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [resizeKey, setResizeKey] = useState(0);
 
   useEffect(() => {
-    if (!ticker) return;
-
-    async function loadPriceData() {
-      setLoading(true);
+    if (!normalizedTickers.length) {
+      setSeriesMap({});
+      setLoading(false);
       setError(null);
-
-      try {
-        let url = `/api/local-data?ticker=${ticker}`;
-        if (dateRange.start) url += `&start=${dateRange.start}`;
-        if (dateRange.end) url += `&end=${dateRange.end}`;
-
-        const response = await fetch(url);
-        const result = await response.json();
-
-        if (result.ok && result.rows) {
-          setData(result.rows);
-        } else {
-          setError(result.error || "Failed to load data");
-        }
-      } catch (err) {
-        setError("Failed to fetch price data");
-        console.error("Error loading price data:", err);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    loadPriceData();
-  }, [ticker, dateRange.start, dateRange.end]);
-
-  useEffect(() => {
-    const element = containerRef.current;
-    if (!element || typeof ResizeObserver === "undefined") {
       return;
     }
 
-    const observer = new ResizeObserver(() => {
-      setResizeKey((prev) => prev + 1);
-    });
+    const controller = new AbortController();
+    const { signal } = controller;
+    setLoading(true);
+    setError(null);
 
-    observer.observe(element);
+    async function load() {
+      try {
+        if (normalizedTickers.length === 1) {
+          const ticker = normalizedTickers[0];
+          const params = new URLSearchParams({ ticker });
+          if (dateRange?.start) params.set("start", dateRange.start);
+          if (dateRange?.end) params.set("end", dateRange.end);
+          const response = await fetch(`/api/local-data?${params.toString()}`, { signal });
+          const json = await response.json();
+          if (!json.ok || !Array.isArray(json.rows)) {
+            throw new Error(json.error || "Failed to load data");
+          }
+          setSeriesMap({ [ticker]: json.rows as PriceRow[] });
+          return;
+        }
 
-    return () => {
-      observer.disconnect();
+        const response = await fetch("/api/local-batch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            tickers: normalizedTickers,
+            startDate: dateRange?.start,
+            endDate: dateRange?.end,
+          }),
+          signal,
+        });
+        const json = await response.json();
+        if (!json.ok || !Array.isArray(json.data)) {
+          throw new Error(json.error || "Failed to load data");
+        }
+        const mapped: Record<string, PriceRow[]> = {};
+        for (const item of json.data) {
+          if (!item || typeof item.ticker !== "string") continue;
+          mapped[item.ticker.toUpperCase()] = Array.isArray(item.bars)
+            ? (item.bars as PriceRow[])
+            : [];
+        }
+        setSeriesMap(mapped);
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
+        console.error("Error loading chart data", err);
+        setError(err instanceof Error ? err.message : "Failed to load data");
+        setSeriesMap({});
+      } finally {
+        if (!signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+    return () => controller.abort();
+  }, [normalizedTickers, dateRange?.start, dateRange?.end]);
+
+  const derived = useMemo(() => {
+    const pricePoints: ChartPoint[] = [];
+    const rsiPoints: ChartPoint[] = [];
+    const macdPoints: ChartPoint[] = [];
+    const tickerSummaries: Array<{
+      ticker: string;
+      latestClose?: number;
+      latestDate?: string;
+      firstDate?: string;
+      changePct?: number;
+      hasData: boolean;
+    }> = [];
+    const missingTickers: string[] = [];
+
+    if (!normalizedTickers.length) {
+      return { pricePoints, rsiPoints, macdPoints, tickerSummaries, missingTickers };
+    }
+
+    const allDates = new Set<string>();
+    for (const ticker of normalizedTickers) {
+      const rows = seriesMap[ticker];
+      if (!rows || rows.length === 0) {
+        tickerSummaries.push({ ticker, hasData: false });
+        missingTickers.push(ticker);
+        continue;
+      }
+      rows.forEach((row) => allDates.add(row.date));
+    }
+
+    const sortedDates = Array.from(allDates).sort();
+    pricePoints.push(...sortedDates.map((date) => ({ date })));
+    if (indicatorState.rsi) {
+      rsiPoints.push(...sortedDates.map((date) => ({ date })));
+    }
+    if (indicatorState.macd) {
+      macdPoints.push(...sortedDates.map((date) => ({ date })));
+    }
+
+    const priceLookup = new Map(pricePoints.map((point) => [point.date, point]));
+    const rsiLookup = new Map(rsiPoints.map((point) => [point.date, point]));
+    const macdLookup = new Map(macdPoints.map((point) => [point.date, point]));
+
+    for (const ticker of normalizedTickers) {
+      const rows = seriesMap[ticker];
+      if (!rows || rows.length === 0) continue;
+
+      const closes = rows.map((row) => row.close ?? NaN);
+      const smaValues = indicatorState.sma ? sma(closes, 20) : [];
+      const emaValues = indicatorState.ema ? ema(closes, 50) : [];
+      const rsiValues = indicatorState.rsi ? rsi(closes) : [];
+      const macdValues = indicatorState.macd ? macd(closes) : undefined;
+
+      const firstRow = rows[0];
+      const lastRow = rows[rows.length - 1];
+      const changePct =
+        firstRow && lastRow && Number.isFinite(firstRow.close) && firstRow.close !== 0
+          ? ((lastRow.close - firstRow.close) / firstRow.close) * 100
+          : undefined;
+      tickerSummaries.push({
+        ticker,
+        firstDate: firstRow?.date,
+        latestClose: lastRow?.close,
+        latestDate: lastRow?.date,
+        changePct,
+        hasData: true,
+      });
+
+      rows.forEach((row, index) => {
+        const base = priceLookup.get(row.date);
+        if (base) {
+          base[ticker] = row.close ?? null;
+          if (indicatorState.sma && smaValues[index] != null) {
+            base[`${ticker}_SMA20`] = smaValues[index];
+          }
+          if (indicatorState.ema && emaValues[index] != null) {
+            base[`${ticker}_EMA50`] = emaValues[index];
+          }
+        }
+        if (indicatorState.rsi && rsiValues[index] != null) {
+          const target = rsiLookup.get(row.date);
+          if (target) {
+            target[`${ticker}_RSI`] = rsiValues[index];
+          }
+        }
+        if (indicatorState.macd && macdValues) {
+          const macdPoint = macdLookup.get(row.date);
+          if (macdPoint) {
+            const macdValue = macdValues.macd[index];
+            const signalValue = macdValues.signal[index];
+            if (macdValue != null) macdPoint[`${ticker}_MACD`] = macdValue;
+            if (signalValue != null) macdPoint[`${ticker}_SIGNAL`] = signalValue;
+          }
+        }
+      });
+    }
+
+    const hasRsi = indicatorState.rsi
+      ? rsiPoints.some((point) =>
+          normalizedTickers.some((ticker) => point[`${ticker}_RSI`] != null),
+        )
+      : false;
+    const hasMacd = indicatorState.macd
+      ? macdPoints.some((point) =>
+          normalizedTickers.some(
+            (ticker) =>
+              point[`${ticker}_MACD`] != null || point[`${ticker}_SIGNAL`] != null,
+          ),
+        )
+      : false;
+
+    return {
+      pricePoints,
+      rsiPoints: hasRsi ? rsiPoints : [],
+      macdPoints: hasMacd ? macdPoints : [],
+      tickerSummaries,
+      missingTickers,
     };
-  }, []);
+  }, [seriesMap, normalizedTickers, indicatorState]);
 
-  const latestPrice = data.length > 0 ? data[data.length - 1] : null;
+  if (!normalizedTickers.length) {
+    return (
+      <div className="rounded-lg border border-dashed border-gray-700 bg-gray-900/60 p-10 text-center text-gray-400">
+        Choose at least one ticker to render the chart.
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-72 items-center justify-center rounded-lg border border-gray-700 bg-gray-900 text-sm text-gray-300">
+        Loading price data…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-72 items-center justify-center rounded-lg border border-red-700/60 bg-red-900/30 px-4 text-center text-sm text-red-200">
+        {error}
+      </div>
+    );
+  }
+
+  const colors = normalizedTickers.reduce<Record<string, string>>((accumulator, ticker, index) => {
+    accumulator[ticker] = SERIES_COLORS[index % SERIES_COLORS.length];
+    return accumulator;
+  }, {});
+
+  const hasPriceData = derived.pricePoints.length > 0;
 
   return (
-    <div className="bg-gray-800 rounded-lg p-4 sm:p-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
-        <h3 className="text-lg font-semibold text-white">
-          {ticker} Price Chart
-        </h3>
-        {latestPrice && (
-          <div className="text-left sm:text-right">
-            <div className="text-xl font-bold text-white">
-              ${latestPrice.close.toFixed(2)}
+    <div className="space-y-6 rounded-lg border border-gray-700 bg-gray-800 p-4 sm:p-6">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {derived.tickerSummaries.map((summary) => (
+          <div
+            key={summary.ticker}
+            className="flex items-center justify-between rounded-md bg-gray-900/50 px-4 py-3 text-sm text-gray-200"
+          >
+            <div>
+              <div className="text-xs uppercase tracking-wide text-gray-400">
+                {(summary.firstDate ?? "—").toString()} → {(summary.latestDate ?? "—").toString()}
+              </div>
+              <div className="text-lg font-semibold text-white">
+                {summary.ticker}
+              </div>
             </div>
-            <div className="text-sm text-gray-400">
-              {latestPrice.date}
+            <div className="text-right">
+              <div className="text-base font-semibold text-blue-200">
+                {summary.latestClose != null ? `$${summary.latestClose.toFixed(2)}` : "—"}
+              </div>
+              <div
+                className={
+                  summary.hasData
+                    ? summary.changePct != null
+                      ? summary.changePct >= 0
+                        ? "text-xs font-medium text-emerald-400"
+                        : "text-xs font-medium text-red-400"
+                      : "text-xs text-gray-500"
+                    : "text-xs text-gray-500"
+                }
+              >
+                {summary.hasData
+                  ? summary.changePct != null
+                    ? `${summary.changePct >= 0 ? "+" : ""}${summary.changePct.toFixed(2)}%`
+                    : "No change data"
+                  : "No local data"}
+              </div>
             </div>
           </div>
-        )}
+        ))}
       </div>
 
-      <div className="flex flex-col sm:flex-row sm:items-end gap-4 mb-4">
-        <div className="flex-1 sm:flex-none">
-          <label className="block text-sm text-gray-400 mb-1">Start Date</label>
-          <input
-            type="date"
-            value={dateRange.start}
-            onChange={(e) => setDateRange(prev => ({ ...prev, start: e.target.value }))}
-            className="px-3 py-1 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-          />
-        </div>
-        <div className="flex-1 sm:flex-none">
-          <label className="block text-sm text-gray-400 mb-1">End Date</label>
-          <input
-            type="date"
-            value={dateRange.end}
-            onChange={(e) => setDateRange(prev => ({ ...prev, end: e.target.value }))}
-            className="px-3 py-1 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-          />
-        </div>
-      </div>
-
-      {loading && (
-        <div className="h-64 flex items-center justify-center border rounded bg-gray-900">
-          <p className="text-sm sm:text-base text-gray-400">Loading chart data...</p>
+      {derived.missingTickers.length > 0 && (
+        <div className="rounded-md border border-amber-600/40 bg-amber-900/20 p-3 text-xs text-amber-200">
+          Some selections have no local data in the chosen range: {derived.missingTickers.join(", ")}
         </div>
       )}
 
-      {error && (
-        <div className="h-64 flex items-center justify-center border rounded bg-red-900/20">
-          <p className="text-sm sm:text-base text-red-400">Error: {error}</p>
-        </div>
-      )}
-
-      {!loading && !error && data.length > 0 && (
-        <div className="w-full space-y-4">
-          <div className="w-full" ref={containerRef} style={{ aspectRatio: "16/9" }}>
-            <PriceLineChart key={resizeKey} data={data} />
+      {hasPriceData ? (
+        <div className="space-y-6">
+          <div className="h-[320px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={derived.pricePoints} margin={{ left: 12, right: 16, bottom: 12 }}>
+                <CartesianGrid strokeDasharray="4 4" stroke="#374151" />
+                <XAxis dataKey="date" stroke="#9CA3AF" tickFormatter={LABEL_DATE_FORMATTER} fontSize={12} minTickGap={24} />
+                <YAxis
+                  stroke="#9CA3AF"
+                  tickFormatter={(value: number) => `$${value.toFixed(2)}`}
+                  fontSize={12}
+                  width={70}
+                />
+                <Tooltip
+                  contentStyle={PRICE_TOOLTIP_STYLE}
+                  labelFormatter={LABEL_DATE_FORMATTER}
+                  formatter={(rawValue: number | string, name) => {
+                    const value = Number(rawValue);
+                    if (!Number.isFinite(value)) return ["—", name];
+                    if (name.includes("RSI")) return [value.toFixed(2), name];
+                    return [`$${value.toFixed(2)}`, name];
+                  }}
+                />
+                <Legend wrapperStyle={{ color: "#E5E7EB" }} />
+                {normalizedTickers.map((ticker) => {
+                  if (!seriesMap[ticker]?.length) return null;
+                  return (
+                    <Line
+                      key={ticker}
+                      type="monotone"
+                      dataKey={ticker}
+                      name={`${ticker} Close`}
+                      stroke={colors[ticker]}
+                      strokeWidth={2}
+                      dot={false}
+                      connectNulls
+                    />
+                  );
+                })}
+                {indicatorState.sma &&
+                  normalizedTickers.map((ticker) => {
+                    if (!seriesMap[ticker]?.length) return null;
+                    return (
+                      <Line
+                        key={`${ticker}-sma`}
+                        type="monotone"
+                        dataKey={`${ticker}_SMA20`}
+                        name={`${ticker} SMA(20)`}
+                        stroke={colors[ticker]}
+                        strokeDasharray="6 2"
+                        strokeWidth={1.5}
+                        dot={false}
+                        connectNulls
+                        opacity={0.9}
+                      />
+                    );
+                  })}
+                {indicatorState.ema &&
+                  normalizedTickers.map((ticker) => {
+                    if (!seriesMap[ticker]?.length) return null;
+                    return (
+                      <Line
+                        key={`${ticker}-ema`}
+                        type="monotone"
+                        dataKey={`${ticker}_EMA50`}
+                        name={`${ticker} EMA(50)`}
+                        stroke={colors[ticker]}
+                        strokeDasharray="3 3"
+                        strokeWidth={1.5}
+                        dot={false}
+                        connectNulls
+                        opacity={0.75}
+                      />
+                    );
+                  })}
+              </LineChart>
+            </ResponsiveContainer>
           </div>
 
-          {latestPrice && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 p-4 bg-gray-700 rounded">
-              <div>
-                <div className="text-xs text-gray-400">Open</div>
-                <div className="text-white font-medium">${latestPrice.open.toFixed(2)}</div>
-              </div>
-              <div>
-                <div className="text-xs text-gray-400">High</div>
-                <div className="text-green-400 font-medium">${latestPrice.high.toFixed(2)}</div>
-              </div>
-              <div>
-                <div className="text-xs text-gray-400">Low</div>
-                <div className="text-red-400 font-medium">${latestPrice.low.toFixed(2)}</div>
-              </div>
-              <div>
-                <div className="text-xs text-gray-400">Volume</div>
-                <div className="text-white font-medium">{latestPrice.volume.toLocaleString()}</div>
-              </div>
+          {indicatorState.rsi && derived.rsiPoints.length > 0 && (
+            <div className="h-[200px] w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={derived.rsiPoints} margin={{ left: 12, right: 16, bottom: 8 }}>
+                  <CartesianGrid strokeDasharray="4 4" stroke="#374151" />
+                  <XAxis dataKey="date" stroke="#9CA3AF" tickFormatter={LABEL_DATE_FORMATTER} fontSize={11} minTickGap={24} />
+                  <YAxis domain={[0, 100]} stroke="#9CA3AF" fontSize={11} width={40} />
+                  <Tooltip
+                    contentStyle={PRICE_TOOLTIP_STYLE}
+                    labelFormatter={LABEL_DATE_FORMATTER}
+                    formatter={(rawValue: number | string, name) => {
+                      const value = Number(rawValue);
+                      if (!Number.isFinite(value)) return ["—", name];
+                      return [value.toFixed(2), name];
+                    }}
+                  />
+                  <Legend wrapperStyle={{ color: "#E5E7EB" }} />
+                  <ReferenceLine y={30} stroke="#F97316" strokeDasharray="4 4" />
+                  <ReferenceLine y={70} stroke="#F97316" strokeDasharray="4 4" />
+                  {normalizedTickers.map((ticker) => {
+                    if (!seriesMap[ticker]?.length) return null;
+                    return (
+                      <Line
+                        key={`${ticker}-rsi`}
+                        type="monotone"
+                        dataKey={`${ticker}_RSI`}
+                        name={`${ticker} RSI(14)`}
+                        stroke={colors[ticker]}
+                        strokeWidth={1.5}
+                        dot={false}
+                        connectNulls
+                      />
+                    );
+                  })}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {indicatorState.macd && derived.macdPoints.length > 0 && (
+            <div className="h-[220px] w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={derived.macdPoints} margin={{ left: 12, right: 16, bottom: 8 }}>
+                  <CartesianGrid strokeDasharray="4 4" stroke="#374151" />
+                  <XAxis dataKey="date" stroke="#9CA3AF" tickFormatter={LABEL_DATE_FORMATTER} fontSize={11} minTickGap={24} />
+                  <YAxis stroke="#9CA3AF" fontSize={11} width={50} />
+                  <Tooltip
+                    contentStyle={PRICE_TOOLTIP_STYLE}
+                    labelFormatter={LABEL_DATE_FORMATTER}
+                    formatter={(rawValue: number | string, name) => {
+                      const value = Number(rawValue);
+                      if (!Number.isFinite(value)) return ["—", name];
+                      return [value.toFixed(3), name];
+                    }}
+                  />
+                  <Legend wrapperStyle={{ color: "#E5E7EB" }} />
+                  <ReferenceLine y={0} stroke="#6B7280" strokeDasharray="2 3" />
+                  {normalizedTickers.map((ticker) => {
+                    if (!seriesMap[ticker]?.length) return null;
+                    return (
+                      <Line
+                        key={`${ticker}-macd`}
+                        type="monotone"
+                        dataKey={`${ticker}_MACD`}
+                        name={`${ticker} MACD`}
+                        stroke={colors[ticker]}
+                        strokeWidth={1.5}
+                        dot={false}
+                        connectNulls
+                      />
+                    );
+                  })}
+                  {normalizedTickers.map((ticker) => {
+                    if (!seriesMap[ticker]?.length) return null;
+                    return (
+                      <Line
+                        key={`${ticker}-macd-signal`}
+                        type="monotone"
+                        dataKey={`${ticker}_SIGNAL`}
+                        name={`${ticker} Signal`}
+                        stroke={colors[ticker]}
+                        strokeDasharray="5 3"
+                        strokeWidth={1.2}
+                        dot={false}
+                        connectNulls
+                        opacity={0.7}
+                      />
+                    );
+                  })}
+                </LineChart>
+              </ResponsiveContainer>
             </div>
           )}
         </div>
-      )}
-
-      {!loading && !error && data.length === 0 && (
-        <div className="h-64 flex items-center justify-center border rounded bg-gray-900">
-          <p className="text-sm sm:text-base text-gray-400">No data available for {ticker}</p>
+      ) : (
+        <div className="flex h-72 items-center justify-center rounded-lg border border-dashed border-gray-700 bg-gray-900/60 text-sm text-gray-400">
+          No price data available for the selected range.
         </div>
       )}
     </div>

--- a/lib/samplePrompt.ts
+++ b/lib/samplePrompt.ts
@@ -1,0 +1,79 @@
+export interface IndicatorSelection {
+  rsi?: boolean;
+  macd?: boolean;
+  sma?: boolean;
+  ema?: boolean;
+}
+
+function formatWindow(start?: string, end?: string): string {
+  if (start && end) return `${start} to ${end}`;
+  if (start) return `starting ${start}`;
+  if (end) return `through ${end}`;
+  return "across the available history";
+}
+
+export function buildSamplePrompt(
+  indicators: IndicatorSelection,
+  tickers: string[],
+  start?: string,
+  end?: string,
+): string {
+  const entryConditions: string[] = [];
+  const exitConditions: string[] = [];
+
+  if (indicators.sma && indicators.ema) {
+    entryConditions.push("SMA(20) crosses above EMA(50)");
+    exitConditions.push("SMA(20) crosses below EMA(50)");
+  } else if (indicators.sma) {
+    entryConditions.push("price closes above SMA(20)");
+    exitConditions.push("price falls back below SMA(20)");
+  } else if (indicators.ema) {
+    entryConditions.push("price closes above EMA(50)");
+    exitConditions.push("price falls back below EMA(50)");
+  }
+
+  if (indicators.rsi) {
+    entryConditions.push("RSI(14) < 30");
+    exitConditions.push("RSI(14) > 70");
+  }
+
+  if (indicators.macd) {
+    entryConditions.push("MACD crosses above its signal line");
+    exitConditions.push("MACD crosses back below the signal line");
+  }
+
+  if (!entryConditions.length) {
+    entryConditions.push("price breaks above recent resistance");
+  }
+  if (!exitConditions.length) {
+    exitConditions.push("price breaks below recent support");
+  }
+
+  const universe = tickers.length ? tickers.join(", ") : "the selected equities";
+  const window = formatWindow(start, end);
+
+  return [
+    `Focus on ${universe}.`,
+    `Enter long when ${entryConditions.join(" and ")}.`,
+    `Exit when ${exitConditions.join(" or ")} while managing risk with stops and position sizing.`,
+    `Evaluate performance ${window}.`,
+  ].join(" ");
+}
+
+export function buildSamplePromptFromKeys(
+  keys: string[],
+  tickers: string[],
+  start?: string,
+  end?: string,
+): string {
+  const selection: IndicatorSelection = {};
+  keys
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)
+    .forEach((key) => {
+      if (key === "sma" || key === "ema" || key === "rsi" || key === "macd") {
+        selection[key] = true;
+      }
+    });
+  return buildSamplePrompt(selection, tickers, start, end);
+}

--- a/lib/useDateLimits.ts
+++ b/lib/useDateLimits.ts
@@ -1,0 +1,113 @@
+interface TickerMeta {
+  firstDate?: string;
+  lastDate?: string;
+}
+
+type MetaMap = Record<string, TickerMeta>;
+
+let cachedMetaPromise: Promise<MetaMap> | null = null;
+
+async function fetchIndexMeta(): Promise<MetaMap> {
+  const map: MetaMap = {};
+  try {
+    const response = await fetch("/api/index");
+    if (!response.ok) {
+      return map;
+    }
+    const data = await response.json();
+    if (!Array.isArray(data?.tickers)) {
+      return map;
+    }
+    for (const entry of data.tickers) {
+      if (!entry) continue;
+      if (typeof entry === "string") {
+        const key = entry.toUpperCase();
+        if (!map[key]) map[key] = {};
+        continue;
+      }
+      if (typeof entry.ticker !== "string") continue;
+      const key = entry.ticker.toUpperCase();
+      if (!map[key]) map[key] = {};
+      if (entry.firstDate) map[key].firstDate = entry.firstDate;
+      if (entry.lastDate) map[key].lastDate = entry.lastDate;
+    }
+  } catch (error) {
+    console.warn("Failed to load /api/index metadata", error);
+  }
+  return map;
+}
+
+async function fetchManifestMeta(existing: MetaMap): Promise<MetaMap> {
+  const map = { ...existing };
+  try {
+    const response = await fetch("/manifest.json");
+    if (!response.ok) {
+      return map;
+    }
+    const data = await response.json();
+    if (!Array.isArray(data?.tickers)) {
+      return map;
+    }
+    for (const entry of data.tickers) {
+      if (!entry || typeof entry.ticker !== "string") continue;
+      const key = entry.ticker.toUpperCase();
+      if (!map[key]) map[key] = {};
+      if (entry.firstDate && !map[key].firstDate) map[key].firstDate = entry.firstDate;
+      if (entry.lastDate && !map[key].lastDate) map[key].lastDate = entry.lastDate;
+    }
+  } catch (error) {
+    console.warn("Failed to load manifest metadata", error);
+  }
+  return map;
+}
+
+export async function getTickerMeta(): Promise<MetaMap> {
+  if (!cachedMetaPromise) {
+    cachedMetaPromise = (async () => {
+      const indexMeta = await fetchIndexMeta();
+      const needsManifest = Object.values(indexMeta).some(
+        (entry) => !entry.firstDate || !entry.lastDate,
+      );
+      if (needsManifest || Object.keys(indexMeta).length === 0) {
+        return fetchManifestMeta(indexMeta);
+      }
+      return indexMeta;
+    })();
+  }
+  return cachedMetaPromise;
+}
+
+export function intersectRange(
+  tickers: string[],
+  metaMap: MetaMap,
+): { min?: string; max?: string } {
+  if (!Array.isArray(tickers) || tickers.length === 0) return {};
+  const normalized = Array.from(new Set(tickers.map((ticker) => ticker.toUpperCase()))).filter(
+    Boolean,
+  );
+  if (normalized.length === 0) return {};
+
+  let minStart: string | undefined;
+  let maxEnd: string | undefined;
+  let hasAny = false;
+
+  for (const ticker of normalized) {
+    const meta = metaMap[ticker];
+    if (!meta) continue;
+    if (meta.firstDate) {
+      hasAny = true;
+      if (!minStart || meta.firstDate > minStart) {
+        minStart = meta.firstDate;
+      }
+    }
+    if (meta.lastDate) {
+      hasAny = true;
+      if (!maxEnd || meta.lastDate < maxEnd) {
+        maxEnd = meta.lastDate;
+      }
+    }
+  }
+
+  if (!hasAny) return {};
+  return { min: minStart, max: maxEnd };
+}

--- a/tests/date-range.intersection.test.ts
+++ b/tests/date-range.intersection.test.ts
@@ -1,0 +1,41 @@
+/// <reference types="vitest" />
+import { describe, expect, it } from "vitest";
+import { intersectRange } from "../lib/useDateLimits";
+
+describe("intersectRange", () => {
+  it("returns bounds for a single ticker", () => {
+    const meta = {
+      AAPL: { firstDate: "2020-01-02", lastDate: "2020-12-31" },
+    };
+    expect(intersectRange(["AAPL"], meta)).toEqual({ min: "2020-01-02", max: "2020-12-31" });
+  });
+
+  it("computes the intersection across multiple tickers", () => {
+    const meta = {
+      AAPL: { firstDate: "2020-01-02", lastDate: "2020-12-31" },
+      MSFT: { firstDate: "2020-03-01", lastDate: "2020-10-15" },
+      NVDA: { firstDate: "2020-02-15", lastDate: "2020-11-30" },
+    };
+    expect(intersectRange(["aapl", "MSFT", "NVDA"], meta)).toEqual({ min: "2020-03-01", max: "2020-10-15" });
+  });
+
+  it("ignores tickers without metadata", () => {
+    const meta = {
+      AAPL: { firstDate: "2020-01-02", lastDate: "2020-12-31" },
+      GOOG: {},
+    } as Record<string, { firstDate?: string; lastDate?: string }>;
+    expect(intersectRange(["AAPL", "GOOG"], meta)).toEqual({ min: "2020-01-02", max: "2020-12-31" });
+  });
+
+  it("returns min greater than max when no overlap exists", () => {
+    const meta = {
+      AAPL: { firstDate: "2020-01-02", lastDate: "2020-03-01" },
+      MSFT: { firstDate: "2020-04-01", lastDate: "2020-06-01" },
+    };
+    expect(intersectRange(["AAPL", "MSFT"], meta)).toEqual({ min: "2020-04-01", max: "2020-03-01" });
+  });
+
+  it("returns empty object when no tickers provided", () => {
+    expect(intersectRange([], {})).toEqual({});
+  });
+});

--- a/tests/indicators.test.ts
+++ b/tests/indicators.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 import { describe, expect, it } from 'vitest';
 import { SMA, EMA, MACD, RSI } from '../lib/indicators';
+import { sma as lightweightSma, ema as lightweightEma, macd as lightweightMacd, rsi as lightweightRsi } from '../components/indicators';
 
 describe('Technical Indicators', () => {
   const testPrices = [100, 102, 104, 103, 105, 107, 106, 108, 110, 109];
@@ -104,6 +105,69 @@ describe('Technical Indicators', () => {
       // RSI should be low (<50) for consistent downtrend
       const lastRSI = rsi[rsi.length - 1];
       expect(lastRSI).toBeLessThan(50);
+    });
+  });
+
+  describe('client indicator helpers', () => {
+    it('matches library SMA output where defined', () => {
+      const period = 3;
+      const legacy = SMA(testPrices, period);
+      const fresh = lightweightSma(testPrices, period);
+
+      expect(fresh).toHaveLength(legacy.length);
+      fresh.forEach((value, index) => {
+        if (value == null) {
+          expect(Number.isNaN(legacy[index])).toBe(true);
+        } else {
+          expect(value).toBeCloseTo(legacy[index], 6);
+        }
+      });
+    });
+
+    it('returns EMA values after the warmup period', () => {
+      const period = 3;
+      const fresh = lightweightEma(testPrices, period);
+
+      expect(fresh).toHaveLength(testPrices.length);
+      for (let index = 0; index < period - 1; index++) {
+        expect(fresh[index]).toBeNull();
+      }
+      expect(fresh[period - 1]).not.toBeNull();
+      for (let index = period; index < fresh.length; index++) {
+        if (fresh[index] != null) {
+          expect(typeof fresh[index]).toBe("number");
+        }
+      }
+    });
+
+    it('produces RSI between 0-100', () => {
+      const values = lightweightRsi(testPrices, 3);
+      const legacy = RSI(testPrices, 3);
+      values.forEach((value, index) => {
+        if (value == null) {
+          expect(Number.isNaN(legacy[index])).toBe(true);
+        } else {
+          expect(value).toBeGreaterThanOrEqual(0);
+          expect(value).toBeLessThanOrEqual(100);
+        }
+      });
+    });
+
+    it('aligns MACD line with EMA differences', () => {
+      const prices = [100, 102, 104, 106, 108, 110];
+      const macd = lightweightMacd(prices, 3, 6, 3);
+      const fast = lightweightEma(prices, 3);
+      const slow = lightweightEma(prices, 6);
+
+      macd.macd.forEach((value, index) => {
+        const fastValue = fast[index];
+        const slowValue = slow[index];
+        if (fastValue == null || slowValue == null) {
+          expect(value).toBeNull();
+        } else {
+          expect(value).toBeCloseTo(fastValue - slowValue, 6);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- enable multi-select on the dashboard ticker selector, share date limits, and add indicator toggles plus strategy deep-linking
- rebuild the price chart to support multi-series data and lightweight RSI/MACD/SMA/EMA overlays
- overhaul Strategy Lab with prefilled query handling, ticker validation, date constraints, and notification UX helpers
- add reusable indicator math + prompt helpers along with coverage tests for date intersections and indicator parity

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d3670e4cdc832b8cf774e8e68cfa88