### PR TITLE
fix: guard tooltip formatter for RSI series

### DIFF
--- a/components/price-chart.tsx
+++ b/components/price-chart.tsx
@@ -365,7 +365,9 @@ export function PriceChart({ tickers, dateRange, indicators }: PriceChartProps) 
                   formatter={(rawValue: number | string, name) => {
                     const value = Number(rawValue);
                     if (!Number.isFinite(value)) return ["—", name];
-                    if (name.includes("RSI")) return [value.toFixed(2), name];
+                    if (typeof name === "string" && name.includes("RSI")) {
+                      return [value.toFixed(2), name];
+                    }
                     return [`$${value.toFixed(2)}`, name];
                   }}
                 />


### PR DESCRIPTION
## Summary
- guard the price chart tooltip formatter so RSI formatting only runs for string legend names

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d3715c72c8832b86b688621f12ace2