### PR TITLE
Fix ticker selection reset when query params missing

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -28,8 +28,10 @@ function DashboardInner() {
   const selectedTicker = selectedTickers[0] ?? "";
 
   useEffect(() => {
+    const hasTickersParam = searchParams.has("tickers");
+    const hasTickerParam = searchParams.has("ticker");
     const tickersParam =
-      searchParams.get("tickers") || searchParams.get("ticker") || "";
+      searchParams.get("tickers") ?? searchParams.get("ticker") ?? "";
     const parsedTickers = tickersParam
       .split(",")
       .map((value) => value.trim().toUpperCase())
@@ -39,7 +41,7 @@ function DashboardInner() {
       if (parsedTickers.join(",") !== selectedTickers.join(",")) {
         setSelectedTickers(parsedTickers);
       }
-    } else if (selectedTickers.length) {
+    } else if ((hasTickersParam || hasTickerParam) && selectedTickers.length) {
       setSelectedTickers([]);
     }
 


### PR DESCRIPTION
## Summary
- keep dashboard ticker selections intact when no query params are present by checking for actual ticker parameters before clearing state

## Testing
- npm run test-simple *(fails: connect ENETUNREACH 198.44.194.28:443 - Local (0.0.0.0:0))*

------
https://chatgpt.com/codex/tasks/task_e_68d375afd910832ba4b4f559b528ffef