### PR TITLE
Improve dashboard multi-ticker handling and indicator restrictions

### DIFF
--- a/components/IndicatorToggles.tsx
+++ b/components/IndicatorToggles.tsx
@@ -2,7 +2,7 @@
 
 import clsx from "clsx";
 
-interface IndicatorState {
+export interface IndicatorState {
   rsi: boolean;
   macd: boolean;
   sma: boolean;
@@ -12,6 +12,9 @@ interface IndicatorState {
 interface IndicatorTogglesProps {
   value: IndicatorState;
   onChange: (value: IndicatorState) => void;
+  disabled?: boolean;
+  disabledReason?: string | null;
+  onDisabledAttempt?: () => void;
 }
 
 const INDICATOR_CONFIG: Array<{ key: keyof IndicatorState; label: string; description: string }> = [
@@ -21,8 +24,18 @@ const INDICATOR_CONFIG: Array<{ key: keyof IndicatorState; label: string; descri
   { key: "macd", label: "MACD", description: "Trend & momentum" },
 ];
 
-export function IndicatorToggles({ value, onChange }: IndicatorTogglesProps) {
+export function IndicatorToggles({
+  value,
+  onChange,
+  disabled = false,
+  disabledReason,
+  onDisabledAttempt,
+}: IndicatorTogglesProps) {
   const toggle = (key: keyof IndicatorState) => {
+    if (disabled) {
+      onDisabledAttempt?.();
+      return;
+    }
     onChange({ ...value, [key]: !value[key] });
   };
 
@@ -32,6 +45,11 @@ export function IndicatorToggles({ value, onChange }: IndicatorTogglesProps) {
       <p className="text-xs text-gray-400">
         Choose overlays and oscillators to display alongside price series.
       </p>
+      {disabledReason && (
+        <div className="rounded-md border border-amber-600/40 bg-amber-900/20 px-3 py-2 text-xs text-amber-200">
+          {disabledReason}
+        </div>
+      )}
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         {INDICATOR_CONFIG.map((indicator) => {
           const active = value[indicator.key];
@@ -40,13 +58,17 @@ export function IndicatorToggles({ value, onChange }: IndicatorTogglesProps) {
               key={indicator.key}
               type="button"
               aria-pressed={active}
+              aria-disabled={disabled || undefined}
               onClick={() => toggle(indicator.key)}
               className={clsx(
                 "flex flex-col items-start gap-1 rounded-md border px-3 py-2 text-left transition",
                 "focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900",
+                disabled
+                  ? "cursor-not-allowed border-gray-700 bg-gray-900/60 text-gray-500"
+                  : undefined,
                 active
                   ? "border-blue-500 bg-blue-600/30 text-white shadow-inner"
-                  : "border-gray-600 bg-gray-900/60 text-gray-200 hover:border-gray-500 hover:bg-gray-700/70"
+                  : "border-gray-600 bg-gray-900/60 text-gray-200 hover:border-gray-500 hover:bg-gray-700/70",
               )}
             >
               <span className="text-sm font-medium tracking-wide">{indicator.label}</span>

--- a/components/ticker-selector.tsx
+++ b/components/ticker-selector.tsx
@@ -67,15 +67,21 @@ export function TickerSelector({
 
     const set = new Set(selectedTickers?.map((value) => value.toUpperCase()));
     const normalized = tickerSymbol.toUpperCase();
-    if (set.has(normalized)) {
+    const wasSelected = set.has(normalized);
+
+    if (wasSelected) {
       set.delete(normalized);
     } else {
       set.add(normalized);
     }
 
-    const next = tickers
+    const ordered = tickers
       .map((item) => item.ticker.toUpperCase())
       .filter((symbol) => set.has(symbol));
+    const next = wasSelected
+      ? ordered
+      : [normalized, ...ordered.filter((symbol) => symbol !== normalized)];
+
     onTickersChange(next);
   };
 
@@ -121,36 +127,28 @@ export function TickerSelector({
 
               if (multi) {
                 return (
-                  <label
+                  <button
                     key={ticker.ticker}
-                    className={`flex items-start gap-3 px-3 py-3 sm:py-2 rounded border transition-colors cursor-pointer text-sm sm:text-base focus-within:outline-none focus-within:ring-2 focus-within:ring-blue-500 ${
+                    type="button"
+                    onClick={() => toggleTicker(ticker.ticker)}
+                    className={`flex w-full items-center justify-between rounded-md border px-3 py-3 sm:py-2 text-left text-sm sm:text-base transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                       isSelected
-                        ? "bg-blue-900/40 border-blue-600 text-white"
-                        : "bg-gray-700/80 border-gray-600 text-gray-200 hover:bg-gray-600/80"
+                        ? "border-blue-500 bg-blue-600/30 text-white shadow-inner"
+                        : "border-gray-700 bg-gray-800/70 text-gray-200 hover:border-blue-400 hover:bg-gray-700/80 hover:text-white"
                     }`}
                   >
-                    <input
-                      type="checkbox"
-                      checked={Boolean(isSelected)}
-                      onChange={() => toggleTicker(ticker.ticker)}
-                      className="mt-1 h-4 w-4 rounded border-gray-500 bg-gray-800 text-blue-500 focus:ring-blue-400"
-                    />
-                    <span className="flex-1">
-                      <span className="flex flex-wrap items-center justify-between gap-2">
-                        <span className="font-medium tracking-wide">{ticker.ticker}</span>
-                        {ticker.records && (
-                          <span className="text-xs sm:text-sm text-gray-300">
-                            {ticker.records.toLocaleString()} records
-                          </span>
-                        )}
-                      </span>
+                    <div className="flex flex-col gap-1">
+                      <span className="font-medium tracking-wide">{ticker.ticker}</span>
                       {ticker.lastDate && (
-                        <span className="block text-xs sm:text-sm text-gray-300 mt-1">
-                          Latest: {ticker.lastDate}
-                        </span>
+                        <span className="text-xs sm:text-sm text-gray-300">Latest: {ticker.lastDate}</span>
                       )}
-                    </span>
-                  </label>
+                    </div>
+                    {ticker.records && (
+                      <span className="text-xs sm:text-sm text-gray-300">
+                        {ticker.records.toLocaleString()} records
+                      </span>
+                    )}
+                  </button>
                 );
               }
 


### PR DESCRIPTION
## Summary
- lock indicator toggles to single ticker selections, surface warnings when locked, and ensure downstream consumers only receive safe indicator state
- restyle the multi-select ticker list so selections highlight instead of rendering checkbox tiles while keeping the active ticker first
- harden chart data derivation to avoid client crashes when combining multiple tickers or invalid series data

## Testing
- not run (npm run lint prompts for an interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68d3798dfbcc832ba3b8cf81c139b358