### PR TITLE
Fix dashboard multi-select and prefill flow

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -199,8 +199,14 @@ function DashboardInner() {
 
     const start = dateRange.start ?? limits.min;
     const end = dateRange.end ?? limits.max;
-    if (start) params.set("start", start);
-    if (end) params.set("end", end);
+    if (start) {
+      params.set("start", start);
+      params.set("startDate", start);
+    }
+    if (end) {
+      params.set("end", end);
+      params.set("endDate", end);
+    }
 
     const activeIndicators = Object.entries(indicators)
       .filter(([, enabled]) => enabled)
@@ -214,7 +220,8 @@ function DashboardInner() {
       params.set("prompt", promptSample);
     }
 
-    router.push(`/strategy?${params.toString()}`);
+    params.set("mode", "dsl");
+    router.push(`/backtester?${params.toString()}`);
   };
 
   return (

--- a/components/strategy-form.tsx
+++ b/components/strategy-form.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import { useState } from "react";
-import { Play, Sparkles, Code, BookOpen } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Sparkles, Code, BookOpen } from "lucide-react";
+
+export interface StrategyFormInitialValues {
+  prompt?: string;
+  mode?: "dsl" | "ml";
+  tickers?: string;
+  startDate?: string;
+  endDate?: string;
+}
 
 interface StrategyFormProps {
   onRunStrategy: (params: {
@@ -12,14 +20,45 @@ interface StrategyFormProps {
     endDate: string;
   }) => void;
   loading: boolean;
+  initialValues?: StrategyFormInitialValues;
 }
 
-export function StrategyForm({ onRunStrategy, loading }: StrategyFormProps) {
-  const [prompt, setPrompt] = useState("");
-  const [mode, setMode] = useState<"dsl" | "ml">("dsl");
-  const [tickers, setTickers] = useState("AAPL");
-  const [startDate, setStartDate] = useState("2023-01-01");
-  const [endDate, setEndDate] = useState("2024-01-01");
+export function StrategyForm({ onRunStrategy, loading, initialValues }: StrategyFormProps) {
+  const [prompt, setPrompt] = useState(initialValues?.prompt ?? "");
+  const [mode, setMode] = useState<"dsl" | "ml">(initialValues?.mode ?? "dsl");
+  const [tickers, setTickers] = useState(initialValues?.tickers ?? "AAPL");
+  const [startDate, setStartDate] = useState(initialValues?.startDate ?? "2023-01-01");
+  const [endDate, setEndDate] = useState(initialValues?.endDate ?? "2024-01-01");
+
+  useEffect(() => {
+    if (initialValues?.prompt != null) {
+      setPrompt(initialValues.prompt);
+    }
+  }, [initialValues?.prompt]);
+
+  useEffect(() => {
+    if (initialValues?.mode) {
+      setMode(initialValues.mode);
+    }
+  }, [initialValues?.mode]);
+
+  useEffect(() => {
+    if (initialValues?.tickers != null) {
+      setTickers(initialValues.tickers);
+    }
+  }, [initialValues?.tickers]);
+
+  useEffect(() => {
+    if (initialValues?.startDate) {
+      setStartDate(initialValues.startDate);
+    }
+  }, [initialValues?.startDate]);
+
+  useEffect(() => {
+    if (initialValues?.endDate) {
+      setEndDate(initialValues.endDate);
+    }
+  }, [initialValues?.endDate]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- sanitize price series data and harden chart derivation to prevent multi-ticker crashes
- refresh the dashboard ticker selector styling for clearer multi-select highlighting
- send dashboard filters to the Strategy Lab backtester and allow that form to prefill from query params

## Testing
- `npm run build` *(fails: unable to download Inter font from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d475d97838832bbae9e089952b285a