### PR TITLE
Fix price row normalization typing

### DIFF
--- a/components/price-chart.tsx
+++ b/components/price-chart.tsx
@@ -68,15 +68,16 @@ function normalizePriceRows(rows: unknown): PriceRow[] {
       continue;
     }
 
-    normalized.push({
-      ...(record as PriceRow),
+    const normalizedRow: PriceRow = {
       date,
       open,
       high,
       low,
       close,
       volume: Number.isFinite(volumeValue) ? volumeValue : 0,
-    });
+    };
+
+    normalized.push(normalizedRow);
   }
 
   return normalized.sort((a, b) => a.date.localeCompare(b.date));


### PR DESCRIPTION
## Summary
- ensure normalized price rows are explicitly constructed as `PriceRow`
- avoid spreading unknown records to maintain type safety during normalization

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68db656169d8832bb615de00126a9da8