### PR TITLE
feat: enable multi-ticker dashboard indicators and strategy shortcut

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -122,10 +122,14 @@ Execution (per ticker):
 
 - `/dashboard`
     - Loads `/api/index`, shows ticker count and quick info
-    - Selecting a ticker loads `/api/local-data` and renders a price chart + small stats
+    - Multi-select tickers to fetch `/api/local-data` for each symbol and merge into overlay charts
+    - Toggle SMA/EMA/RSI/MACD overlays (SMA/EMA periods editable via double-click); indicator values computed client-side via `lib/indicators`
+    - Start/end date inputs auto-fill to the combined data range and can be reset to the full span
+    - "Create a strategy with this" button passes selected tickers/indicators/date range to the Strategy Lab via query params
 
 - `/backtester`
-    - Textarea for prompt → `/api/strategy/generate` → DSL JSON
+    - Textarea for prompt/DSL → `/api/strategy/generate` → DSL JSON
+    - Prefills DSL/tickers/date range when navigated from the dashboard shortcut
     - Allows manual DSL editing
     - Runs `/api/strategy/run`, shows equity curve, trades, metrics
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Web-based, AI-powered strategy backtesting over historical market data stored as
 - S3-first data access: reads Parquet/CSV over HTTPS from `s3://<bucket>/<prefix>/` (no local fs)
 - Manifest-driven: `index.json` in S3 lists tickers & metadata for Dashboard/Data Explorer
 - AI backtester: `/api/strategy/generate` converts prompts to DSL; `/api/strategy/run` executes it
-- Charts & UI: Recharts + Tailwind. Pages for Dashboard, Backtester, Data Explorer
+- Dashboard comparisons: select multiple tickers, overlay SMA/EMA/RSI/MACD (adjustable windows), auto-fit date ranges, and launch the Strategy Lab with one click
+- Charts & UI: Recharts + Tailwind with multi-ticker overlays, indicator toggles, and quick hand-offs to the Strategy Lab
 - Tests: Vitest unit tests for normalizers/engine helpers
 
 ## Architecture
@@ -35,8 +36,8 @@ Web-based, AI-powered strategy backtesting over historical market data stored as
 ## Repository Layout
 
 - `app/`
-    - `dashboard/` — Dashboard UI: ticker list, chart
-    - `strategy/` — AI backtester interface (prompt → DSL → run)
+    - `dashboard/` — Dashboard UI: multi-select tickers, indicator overlays, strategy shortcut
+    - `strategy/` — AI backtester interface (DSL editor, prefilled via dashboard shortcut)
     - `api/` — Next.js API routes (Node runtime)
 - `lib/`
     - `env.ts` — environment helpers
@@ -114,6 +115,7 @@ Keep `.env.local` as the source of truth locally; replicate these in Vercel → 
 
 - Open `/backtester`, enter a prompt like:
     - “EMA 12/26 long on cross up; exit on cross down”
+- Or jump from the dashboard via **Create a strategy with this** to pre-fill tickers/indicators.
 - Choose one or more tickers, pick a date range, and run.
 - You’ll see equity curve, trades, and summary stats.
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,118 +1,392 @@
 // app/dashboard/page.tsx
 "use client";
 
-import { Suspense } from "react";
-import { useState, useEffect } from "react";
-import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { TickerSelector } from "@/components/ticker-selector";
 import { PriceChart } from "@/components/price-chart";
 import Link from "next/link";
+import { EMA, MACD, RSI, SMA } from "@/lib/indicators";
+
+interface PriceRow {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+interface CombinedPoint {
+  date: string;
+  [key: string]: number | string | null;
+}
+
+const COLORS = [
+  "#3B82F6",
+  "#F59E0B",
+  "#10B981",
+  "#EF4444",
+  "#8B5CF6",
+  "#F97316",
+  "#14B8A6",
+  "#EC4899",
+  "#22D3EE",
+  "#6366F1",
+];
+
+function normaliseTickers(input: string | null): string[] {
+  if (!input) return [];
+  return input
+    .split(",")
+    .map((value) => value.trim().toUpperCase())
+    .filter((value, index, self) => value && self.indexOf(value) === index);
+}
+
+function isWithinRange(date: string, start: string, end: string): boolean {
+  if (!start && !end) return true;
+  const ts = Date.parse(date);
+  if (Number.isNaN(ts)) return false;
+  if (start) {
+    const startTs = Date.parse(start);
+    if (!Number.isNaN(startTs) && ts < startTs) return false;
+  }
+  if (end) {
+    const endTs = Date.parse(end);
+    if (!Number.isNaN(endTs) && ts > endTs) return false;
+  }
+  return true;
+}
 
 function DashboardInner() {
-  const [selectedTicker, setSelectedTicker] = useState<string>("");
+  const router = useRouter();
   const searchParams = useSearchParams();
+  const [initialisedFromParams, setInitialisedFromParams] = useState(false);
+
+  const [selectedTickers, setSelectedTickers] = useState<string[]>([]);
+  const [rawData, setRawData] = useState<Record<string, PriceRow[]>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dateRange, setDateRange] = useState({ start: "", end: "" });
+  const [availableRange, setAvailableRange] = useState({ start: "", end: "" });
+  const [showSMA, setShowSMA] = useState(false);
+  const [showEMA, setShowEMA] = useState(false);
+  const [showRSI, setShowRSI] = useState(false);
+  const [showMACD, setShowMACD] = useState(false);
+  const [smaPeriod, setSmaPeriod] = useState(50);
+  const [emaPeriod, setEmaPeriod] = useState(20);
 
   useEffect(() => {
-    const t = searchParams.get("ticker");
-    if (t) setSelectedTicker(t.toUpperCase());
-  }, [searchParams]);
+    if (initialisedFromParams) return;
+    const tickersFromParams = normaliseTickers(searchParams.get("tickers") ?? searchParams.get("ticker"));
+    if (tickersFromParams.length) {
+      setSelectedTickers(tickersFromParams);
+    }
+    const startParam = searchParams.get("start");
+    const endParam = searchParams.get("end");
+    if (startParam || endParam) {
+      setDateRange({ start: startParam ?? "", end: endParam ?? "" });
+    }
+    setInitialisedFromParams(true);
+  }, [searchParams, initialisedFromParams]);
 
-return (
+  useEffect(() => {
+    if (!selectedTickers.length) {
+      setRawData({});
+      setAvailableRange({ start: "", end: "" });
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const responses = await Promise.all(
+          selectedTickers.map(async (ticker) => {
+            const response = await fetch(`/api/local-data?ticker=${ticker}`);
+            if (!response.ok) {
+              throw new Error(`Failed to load data for ${ticker}`);
+            }
+            const result = await response.json();
+            return { ticker, rows: Array.isArray(result.rows) ? (result.rows as PriceRow[]) : [] };
+          }),
+        );
+
+        if (cancelled) return;
+
+        const dataMap: Record<string, PriceRow[]> = {};
+        let minDate: string | null = null;
+        let maxDate: string | null = null;
+
+        for (const { ticker, rows } of responses) {
+          dataMap[ticker] = rows;
+          if (rows.length) {
+            const first = rows[0].date;
+            const last = rows[rows.length - 1].date;
+            if (!minDate || first < minDate) minDate = first;
+            if (!maxDate || last > maxDate) maxDate = last;
+          }
+        }
+
+        setRawData(dataMap);
+        if (minDate && maxDate) {
+          const nextRange = { start: minDate, end: maxDate };
+          setAvailableRange(nextRange);
+          setDateRange(nextRange);
+        } else {
+          setAvailableRange({ start: "", end: "" });
+          setDateRange({ start: "", end: "" });
+        }
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Failed to fetch price data", err);
+        setError(err instanceof Error ? err.message : String(err));
+        setRawData({});
+        setAvailableRange({ start: "", end: "" });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedTickers]);
+
+  const colorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    selectedTickers.forEach((ticker, index) => {
+      map[ticker] = COLORS[index % COLORS.length];
+    });
+    return map;
+  }, [selectedTickers]);
+
+  const { priceData, rsiData, macdData, latestSnapshots } = useMemo(() => {
+    const priceEntries = new Map<string, CombinedPoint>();
+    const rsiEntries = new Map<string, CombinedPoint>();
+    const macdEntries = new Map<string, CombinedPoint>();
+    const latest: Record<string, PriceRow | null> = {};
+
+    for (const ticker of selectedTickers) {
+      const rows = rawData[ticker] ?? [];
+      if (!rows.length) {
+        latest[ticker] = null;
+        continue;
+      }
+
+      const closes = rows.map((row) => row.close);
+      const smaSeries = showSMA ? SMA(closes, Math.max(1, smaPeriod)) : null;
+      const emaSeries = showEMA ? EMA(closes, Math.max(1, emaPeriod)) : null;
+      const rsiSeries = showRSI ? RSI(closes, 14) : null;
+      const macdSeries = showMACD ? MACD(closes) : null;
+
+      const filteredRows = rows.filter((row) => isWithinRange(row.date, dateRange.start, dateRange.end));
+      latest[ticker] = filteredRows.length ? filteredRows[filteredRows.length - 1] : rows[rows.length - 1];
+
+      for (let index = 0; index < rows.length; index++) {
+        const row = rows[index];
+        if (!isWithinRange(row.date, dateRange.start, dateRange.end)) continue;
+
+        const ensureEntry = (map: Map<string, CombinedPoint>) => {
+          if (!map.has(row.date)) {
+            map.set(row.date, { date: row.date });
+          }
+          return map.get(row.date)!;
+        };
+
+        const priceEntry = ensureEntry(priceEntries);
+        priceEntry[ticker] = row.close;
+
+        if (smaSeries && Number.isFinite(smaSeries[index])) {
+          priceEntry[`${ticker}_SMA`] = Number(smaSeries[index].toFixed(4));
+        }
+        if (emaSeries && Number.isFinite(emaSeries[index])) {
+          priceEntry[`${ticker}_EMA`] = Number(emaSeries[index].toFixed(4));
+        }
+        if (rsiSeries && Number.isFinite(rsiSeries[index])) {
+          const rsiEntry = ensureEntry(rsiEntries);
+          rsiEntry[`${ticker}_RSI`] = Number(rsiSeries[index].toFixed(2));
+        }
+        if (macdSeries) {
+          const macdValue = macdSeries.macd[index];
+          const signalValue = macdSeries.signal[index];
+          if (Number.isFinite(macdValue) || Number.isFinite(signalValue)) {
+            const macdEntry = ensureEntry(macdEntries);
+            if (Number.isFinite(macdValue)) {
+              macdEntry[`${ticker}_MACD`] = Number(macdValue.toFixed(4));
+            }
+            if (Number.isFinite(signalValue)) {
+              macdEntry[`${ticker}_MACD_SIGNAL`] = Number(signalValue.toFixed(4));
+            }
+          }
+        }
+      }
+    }
+
+    const sortEntries = (map: Map<string, CombinedPoint>) =>
+      Array.from(map.values()).sort((a, b) => a.date.localeCompare(b.date));
+
+    return {
+      priceData: sortEntries(priceEntries),
+      rsiData: sortEntries(rsiEntries),
+      macdData: sortEntries(macdEntries),
+      latestSnapshots: latest,
+    };
+  }, [
+    selectedTickers,
+    rawData,
+    dateRange.start,
+    dateRange.end,
+    showSMA,
+    showEMA,
+    showRSI,
+    showMACD,
+    smaPeriod,
+    emaPeriod,
+  ]);
+
+  const handleDateRangeChange = (range: { start?: string; end?: string }) => {
+    setDateRange((prev) => ({
+      start: range.start ?? prev.start,
+      end: range.end ?? prev.end,
+    }));
+  };
+
+  const handleResetRange = () => {
+    setDateRange(availableRange);
+  };
+
+  const indicatorConfig = {
+    showSMA,
+    showEMA,
+    showRSI,
+    showMACD,
+    smaPeriod,
+    emaPeriod,
+    toggleSMA: () => setShowSMA((prev) => !prev),
+    toggleEMA: () => setShowEMA((prev) => !prev),
+    toggleRSI: () => setShowRSI((prev) => !prev),
+    toggleMACD: () => setShowMACD((prev) => !prev),
+    changeSmaPeriod: (period: number) => setSmaPeriod(Math.max(1, period)),
+    changeEmaPeriod: (period: number) => setEmaPeriod(Math.max(1, period)),
+  };
+
+  const indicatorParams: string[] = [];
+  if (showSMA) indicatorParams.push(`SMA${smaPeriod}`);
+  if (showEMA) indicatorParams.push(`EMA${emaPeriod}`);
+  if (showRSI) indicatorParams.push("RSI");
+  if (showMACD) indicatorParams.push("MACD");
+
+  const handleCreateStrategy = () => {
+    if (!selectedTickers.length) return;
+    const params = new URLSearchParams();
+    params.set("tickers", selectedTickers.join(","));
+    if (indicatorParams.length) {
+      params.set("indicators", indicatorParams.join(","));
+    }
+    if (dateRange.start) params.set("start", dateRange.start);
+    if (dateRange.end) params.set("end", dateRange.end);
+    router.push(`/strategy?${params.toString()}`);
+  };
+
+  return (
     <Suspense fallback={<div className="p-6 text-gray-300">Loading…</div>}>
       <main className="min-h-screen bg-gray-900">
-      <div className="container mx-auto px-6 py-8">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-white mb-2">Dashboard</h1>
-          <p className="text-gray-400">
-            Real-time overview of available stock tickers and price data visualization
-          </p>
-        </div>
+        <div className="container mx-auto px-6 py-8">
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold text-white mb-2">Dashboard</h1>
+            <p className="text-gray-400">
+              Compare multiple tickers, overlay key indicators, and jump straight into strategy design.
+            </p>
+          </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Ticker Selection Panel */}
-          <div className="lg:col-span-1">
-            <TickerSelector
-              onTickerSelect={setSelectedTicker}
-              selectedTicker={selectedTicker}
-            />
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="lg:col-span-1 space-y-4">
+              <TickerSelector selectedTickers={selectedTickers} onSelectionChange={setSelectedTickers} />
 
-            {selectedTicker && (
-              <div className="mt-4 p-4 bg-blue-900/30 rounded-lg border border-blue-700">
-                <h4 className="text-white font-medium mb-2">Selected</h4>
-                <div className="text-blue-200">
-                  <div className="text-lg font-bold">{selectedTicker}</div>
-                  <div className="text-sm text-blue-300">
-                    Click a ticker to view its price chart and data
-                  </div>
+              <div className="p-4 bg-gray-800 rounded-lg border border-gray-700 text-sm text-gray-300 space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-white font-semibold">Quick Actions</span>
+                  <span className="text-xs text-gray-500">Tools</span>
                 </div>
-              </div>
-            )}
-
-            <div className="mt-4 p-3 bg-gray-800 rounded-lg text-sm">
-              <h4 className="text-white font-medium mb-2">Quick Actions</h4>
-              <div className="space-y-2">
                 <Link
                   href="/backtester"
-                  className="block w-full text-left px-3 py-2 bg-green-600 hover:bg-green-700 rounded text-white transition-colors"
+                  className="block w-full text-left px-3 py-2 bg-green-600/80 hover:bg-green-600 rounded text-white transition-colors"
                 >
                   → Test Trading Strategy
                 </Link>
                 <Link
                   href="/data"
-                  className="block w-full text-left px-3 py-2 bg-purple-600 hover:bg-purple-700 rounded text-white transition-colors"
+                  className="block w-full text-left px-3 py-2 bg-purple-600/80 hover:bg-purple-600 rounded text-white transition-colors"
                 >
                   → Explore Data
                 </Link>
               </div>
             </div>
-          </div>
 
-          {/* Chart Panel */}
-          <div className="lg:col-span-2">
-            {selectedTicker ? (
-              <PriceChart ticker={selectedTicker} />
-            ) : (
-              <div className="bg-gray-800 rounded-lg p-8 text-center">
-                <div className="text-gray-400 mb-4">
-                  <svg className="w-16 h-16 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a 2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                  </svg>
+            <div className="lg:col-span-2 space-y-4">
+              <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                <div>
+                  <h2 className="text-2xl font-semibold text-white">Visual Analysis</h2>
+                  <p className="text-sm text-gray-400">
+                    Toggle indicators to reveal trends. Use the action button to test these ideas in the Strategy Lab.
+                  </p>
                 </div>
-                <h3 className="text-xl font-semibold text-white mb-2">
-                  Select a Ticker to View Chart
-                </h3>
-                <p className="text-gray-400">
-                  Choose a stock ticker from the list on the left to display its historical price data and interactive chart.
-                </p>
+                <button
+                  type="button"
+                  onClick={handleCreateStrategy}
+                  disabled={!selectedTickers.length}
+                  className="self-start md:self-auto px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Create a strategy with this
+                </button>
               </div>
-            )}
-          </div>
-        </div>
 
-        {/* Status Bar */}
-        <div className="mt-8 p-4 bg-gray-800 rounded-lg border border-gray-700">
-          <div className="flex items-center justify-between text-sm">
-            <div className="flex items-center space-x-4">
-              <div className="flex items-center">
-                <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
-                <span className="text-gray-300">Data Source: S3</span>
-              </div>
-              <div className="flex items-center">
-                <div className="w-2 h-2 bg-blue-500 rounded-full mr-2"></div>
-                <span className="text-gray-300">API Status: Active</span>
-              </div>
+              <PriceChart
+                tickers={selectedTickers}
+                loading={loading}
+                error={error}
+                priceData={priceData}
+                rsiData={rsiData}
+                macdData={macdData}
+                dateRange={dateRange}
+                availableRange={availableRange}
+                onDateRangeChange={handleDateRangeChange}
+                onResetDateRange={handleResetRange}
+                indicatorConfig={indicatorConfig}
+                colorMap={colorMap}
+                latestSnapshots={latestSnapshots}
+              />
             </div>
-            <div className="text-gray-400">
-              Last Updated: {new Date().toLocaleString()}
+          </div>
+
+          <div className="mt-8 p-4 bg-gray-800 rounded-lg border border-gray-700">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between text-sm">
+              <div className="flex flex-wrap items-center gap-4 text-gray-300">
+                <div className="flex items-center">
+                  <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
+                  <span>Data Source: S3 Manifest</span>
+                </div>
+                <div className="flex items-center">
+                  <div className="w-2 h-2 bg-blue-500 rounded-full mr-2"></div>
+                  <span>API Status: Active</span>
+                </div>
+                <div className="flex items-center">
+                  <div className="w-2 h-2 bg-yellow-400 rounded-full mr-2"></div>
+                  <span>Indicators: {indicatorParams.length ? indicatorParams.join(", ") : "None selected"}</span>
+                </div>
+              </div>
+              <div className="text-gray-400">Last Updated: {new Date().toLocaleString()}</div>
             </div>
           </div>
         </div>
-      </div>
-    </main>
+      </main>
     </Suspense>
   );
 }
-
 
 export default function DashboardPage() {
   return (

--- a/app/strategy/page.tsx
+++ b/app/strategy/page.tsx
@@ -1,19 +1,128 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 
-const DEFAULT_DSL = `{
-  "tickers": ["AAPL","MSFT"],
-  "rules": [
-    {"type":"sma","length":10,"field":"close","alias":"sma10"},
-    {"type":"cross","fast":"close","slow":"sma10","enter":"fast_above","exit":"fast_below"}
+const DEFAULT_TICKERS = ["AAPL", "MSFT"];
+
+const DEFAULT_DSL_OBJECT = {
+  name: "SMA Crossover",
+  tickers: DEFAULT_TICKERS,
+  startDate: "2020-01-01",
+  endDate: new Date().toISOString().slice(0, 10),
+  capital: 100000,
+  rules: [
+    { type: "sma_cross", params: { fast: 10, slow: 30, enter: "fast_above", exit: "fast_below" } },
   ],
-  "capital": 100000
-}`;
+};
+
+const DEFAULT_DSL = JSON.stringify(DEFAULT_DSL_OBJECT, null, 2);
+
+type IndicatorDescriptor = {
+  type: "SMA" | "EMA" | "RSI" | "MACD";
+  period?: number;
+};
+
+function parseIndicators(raw: string | null): IndicatorDescriptor[] {
+  if (!raw) return [];
+  const descriptors: IndicatorDescriptor[] = [];
+  for (const token of raw.split(",")) {
+    const value = token.trim().toUpperCase();
+    if (!value) continue;
+    const match = value.match(/^(SMA|EMA)(\d+)$/i);
+    if (match) {
+      descriptors.push({ type: match[1].toUpperCase() as "SMA" | "EMA", period: Number(match[2]) });
+      continue;
+    }
+    if (value === "RSI" || value === "MACD") {
+      descriptors.push({ type: value as "RSI" | "MACD" });
+    }
+  }
+  return descriptors;
+}
+
+function normaliseTickers(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((value) => value.trim().toUpperCase())
+    .filter((value, index, self) => value && self.indexOf(value) === index);
+}
+
+function buildDslFromSelection(
+  tickers: string[],
+  indicators: IndicatorDescriptor[],
+  startDate: string | null,
+  endDate: string | null,
+): string {
+  if (!tickers.length) {
+    return DEFAULT_DSL;
+  }
+
+  const rules: any[] = [];
+
+  for (const indicator of indicators) {
+    switch (indicator.type) {
+      case "SMA": {
+        const slow = indicator.period ?? 50;
+        const fast = Math.max(2, Math.round(slow / 2));
+        rules.push({ type: "sma_cross", params: { fast, slow, enter: "fast_above", exit: "fast_below" } });
+        break;
+      }
+      case "EMA": {
+        const slow = indicator.period ?? 20;
+        const fast = Math.max(2, Math.round(slow / 2));
+        rules.push({ type: "ema_cross", params: { fast, slow, enter: "fast_above", exit: "fast_below" } });
+        break;
+      }
+      case "RSI": {
+        rules.push({ type: "rsi_threshold", params: { period: 14, low: 30, high: 70, enter: "long", exit: "long" } });
+        break;
+      }
+      case "MACD": {
+        rules.push({ type: "macd_cross", params: { fast: 12, slow: 26, signal: 9, enter: "bull", exit: "bear" } });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if (!rules.length) {
+    rules.push({ type: "sma_cross", params: { fast: 10, slow: 30, enter: "fast_above", exit: "fast_below" } });
+  }
+
+  const dslObject = {
+    name: "Dashboard Strategy",
+    tickers,
+    startDate: startDate ?? DEFAULT_DSL_OBJECT.startDate,
+    endDate: endDate ?? DEFAULT_DSL_OBJECT.endDate,
+    capital: 100000,
+    rules,
+  };
+
+  return JSON.stringify(dslObject, null, 2);
+}
 
 export default function StrategyPage() {
-  const [dsl, setDsl] = useState(DEFAULT_DSL);
+  const searchParams = useSearchParams();
+  const derivedDsl = useMemo(() => {
+    const tickers = normaliseTickers(searchParams.get("tickers"));
+    const indicators = parseIndicators(searchParams.get("indicators"));
+    const start = searchParams.get("start");
+    const end = searchParams.get("end");
+    if (!tickers.length) {
+      return DEFAULT_DSL;
+    }
+    return buildDslFromSelection(tickers, indicators, start, end);
+  }, [searchParams]);
+
+  const [dsl, setDsl] = useState(derivedDsl);
   const [result, setResult] = useState<any>(null);
   const [err, setErr] = useState("");
+
+  useEffect(() => {
+    setDsl(derivedDsl);
+  }, [derivedDsl]);
 
   const run = async () => {
     setErr("");
@@ -31,12 +140,29 @@ export default function StrategyPage() {
   };
 
   return (
-    <div className="p-8 text-white">
-      <h1 className="text-2xl font-bold">Strategy Lab</h1>
-      <textarea value={dsl} onChange={(e) => setDsl(e.target.value)} className="w-full h-64 text-black p-2 mt-4 rounded" />
-      <button onClick={run} className="mt-3 px-4 py-2 bg-blue-600 rounded">Run</button>
-      {err && <pre className="mt-4 text-red-400">{err}</pre>}
-      {result && <pre className="mt-4 whitespace-pre-wrap">{JSON.stringify(result, null, 2)}</pre>}
+    <div className="p-8 text-white space-y-6 min-h-screen bg-gray-900">
+      <div>
+        <h1 className="text-3xl font-bold">Strategy Lab</h1>
+        <p className="text-gray-300 mt-1 text-sm">
+          Paste or tweak the strategy DSL below, then run it against the selected tickers.
+        </p>
+      </div>
+
+      <textarea
+        value={dsl}
+        onChange={(e) => setDsl(e.target.value)}
+        className="w-full h-72 text-sm text-gray-100 bg-gray-800 border border-gray-700 rounded-lg p-4 font-mono focus:outline-none focus:border-blue-500"
+      />
+
+      <button
+        onClick={run}
+        className="px-4 py-2 bg-blue-600 rounded-md text-sm font-semibold hover:bg-blue-500 disabled:opacity-50"
+      >
+        Run backtest
+      </button>
+
+      {err && <pre className="mt-4 text-red-400 whitespace-pre-wrap">{err}</pre>}
+      {result && <pre className="mt-4 whitespace-pre-wrap bg-gray-800/80 border border-gray-700 rounded-lg p-4">{JSON.stringify(result, null, 2)}</pre>}
     </div>
   );
 }

--- a/components/price-chart.tsx
+++ b/components/price-chart.tsx
@@ -1,9 +1,24 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { PriceLineChart } from "./ui/chart";
+import { useState, useEffect, type MouseEvent } from "react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ReferenceLine,
+} from "recharts";
 
-interface PriceData {
+interface ChartPoint {
+  date: string;
+  [key: string]: number | string | null;
+}
+
+interface LatestSnapshot {
   date: string;
   open: number;
   high: number;
@@ -12,133 +27,461 @@ interface PriceData {
   volume: number;
 }
 
-interface PriceChartProps {
-  ticker: string;
+interface IndicatorConfig {
+  showSMA: boolean;
+  showEMA: boolean;
+  showRSI: boolean;
+  showMACD: boolean;
+  smaPeriod: number;
+  emaPeriod: number;
+  toggleSMA: () => void;
+  toggleEMA: () => void;
+  toggleRSI: () => void;
+  toggleMACD: () => void;
+  changeSmaPeriod: (period: number) => void;
+  changeEmaPeriod: (period: number) => void;
 }
 
-export function PriceChart({ ticker }: PriceChartProps) {
-  const [data, setData] = useState<PriceData[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [dateRange, setDateRange] = useState({
-    start: "",
-    end: ""
-  });
+interface PriceChartProps {
+  tickers: string[];
+  loading: boolean;
+  error: string | null;
+  priceData: ChartPoint[];
+  rsiData: ChartPoint[];
+  macdData: ChartPoint[];
+  dateRange: { start: string; end: string };
+  availableRange: { start: string; end: string };
+  onDateRangeChange: (range: { start?: string; end?: string }) => void;
+  onResetDateRange: () => void;
+  indicatorConfig: IndicatorConfig;
+  colorMap: Record<string, string>;
+  latestSnapshots: Record<string, LatestSnapshot | null>;
+}
+
+function formatCurrency(value: number | string | null): string {
+  if (value === null) return "";
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "";
+  return `$${num.toFixed(2)}`;
+}
+
+function IndicatorToggle({
+  label,
+  checked,
+  onToggle,
+  period,
+  onPeriodChange,
+}: {
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+  period?: number;
+  onPeriodChange?: (value: number) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(period ? String(period) : "");
 
   useEffect(() => {
-    if (!ticker) return;
-
-    async function loadPriceData() {
-      setLoading(true);
-      setError(null);
-
-      try {
-        let url = `/api/local-data?ticker=${ticker}`;
-        if (dateRange.start) url += `&start=${dateRange.start}`;
-        if (dateRange.end) url += `&end=${dateRange.end}`;
-
-        const response = await fetch(url);
-        const result = await response.json();
-
-        if (result.ok && result.rows) {
-          setData(result.rows);
-        } else {
-          setError(result.error || "Failed to load data");
-        }
-      } catch (err) {
-        setError("Failed to fetch price data");
-        console.error("Error loading price data:", err);
-      } finally {
-        setLoading(false);
-      }
+    if (period) {
+      setDraft(String(period));
     }
+  }, [period]);
 
-    loadPriceData();
-  }, [ticker, dateRange.start, dateRange.end]);
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (event.detail > 1) return;
+    onToggle();
+  };
 
-  const latestPrice = data.length > 0 ? data[data.length - 1] : null;
+  const handleDoubleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (!onPeriodChange) return;
+    event.preventDefault();
+    event.stopPropagation();
+    setDraft(period ? String(period) : "");
+    setEditing(true);
+  };
+
+  const commit = () => {
+    if (!onPeriodChange) {
+      setEditing(false);
+      return;
+    }
+    const value = Number(draft);
+    if (Number.isFinite(value) && value > 0) {
+      onPeriodChange(Math.round(value));
+    }
+    setEditing(false);
+  };
 
   return (
-    <div className="bg-gray-800 rounded-lg p-4">
-      <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-semibold text-white">
-          {ticker} Price Chart
-        </h3>
-        {latestPrice && (
-          <div className="text-right">
-            <div className="text-xl font-bold text-white">
-              ${latestPrice.close.toFixed(2)}
-            </div>
-            <div className="text-sm text-gray-400">
-              {latestPrice.date}
-            </div>
-          </div>
+    <div className={`relative inline-flex items-center`}>
+      <button
+        type="button"
+        onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
+        className={`px-3 py-1 rounded-full border text-sm transition-colors ${
+          checked ? "bg-blue-600/80 border-blue-400 text-white" : "bg-gray-700 border-gray-500 text-gray-200 hover:bg-gray-600"
+        }`}
+      >
+        <span className="font-medium">{label}</span>
+        {typeof period === "number" && !editing && (
+          <span className="ml-1 text-xs text-gray-200/80">({period})</span>
         )}
+      </button>
+      {editing && onPeriodChange && (
+        <div className="absolute top-full mt-2 left-1/2 -translate-x-1/2 bg-gray-900 border border-blue-500 rounded-lg p-2 shadow-xl z-10">
+          <div className="text-xs text-gray-300 mb-1">Set period</div>
+          <input
+            type="number"
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={commit}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") commit();
+              if (event.key === "Escape") {
+                setEditing(false);
+              }
+            }}
+            min={1}
+            className="w-20 px-2 py-1 bg-gray-800 border border-blue-500 rounded text-white text-sm focus:outline-none"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PriceChart({
+  tickers,
+  loading,
+  error,
+  priceData,
+  rsiData,
+  macdData,
+  dateRange,
+  availableRange,
+  onDateRangeChange,
+  onResetDateRange,
+  indicatorConfig,
+  colorMap,
+  latestSnapshots,
+}: PriceChartProps) {
+  const {
+    showSMA,
+    showEMA,
+    showRSI,
+    showMACD,
+    smaPeriod,
+    emaPeriod,
+    toggleSMA,
+    toggleEMA,
+    toggleRSI,
+    toggleMACD,
+    changeSmaPeriod,
+    changeEmaPeriod,
+  } = indicatorConfig;
+
+  const hasSelection = tickers.length > 0;
+  const hasPriceData = priceData.length > 0;
+
+  return (
+    <div className="bg-gray-800 rounded-lg p-5 space-y-6 border border-gray-700">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold text-white">Price &amp; Indicator View</h3>
+          {hasSelection ? (
+            <p className="text-sm text-gray-400 mt-1">
+              Comparing {tickers.join(", ")} over {dateRange.start || "?"} to {dateRange.end || "?"}.
+            </p>
+          ) : (
+            <p className="text-sm text-gray-400 mt-1">Select one or more tickers to view their performance.</p>
+          )}
+          {availableRange.start && availableRange.end && (
+            <p className="text-xs text-gray-500 mt-1">
+              Available data span: {availableRange.start} to {availableRange.end}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap items-end gap-3">
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">Start Date</label>
+            <input
+              type="date"
+              value={dateRange.start}
+              onChange={(event) => onDateRangeChange({ start: event.target.value })}
+              className="px-3 py-1.5 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">End Date</label>
+            <input
+              type="date"
+              value={dateRange.end}
+              onChange={(event) => onDateRangeChange({ end: event.target.value })}
+              className="px-3 py-1.5 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={onResetDateRange}
+            className="h-9 px-3 rounded border border-blue-500 text-blue-200 text-sm hover:bg-blue-600/20 disabled:opacity-40 disabled:cursor-not-allowed"
+            disabled={!availableRange.start || (!dateRange.start && !dateRange.end)}
+          >
+            Reset range
+          </button>
+        </div>
       </div>
 
-      <div className="flex gap-4 mb-4">
-        <div>
-          <label className="block text-sm text-gray-400 mb-1">Start Date</label>
-          <input
-            type="date"
-            value={dateRange.start}
-            onChange={(e) => setDateRange(prev => ({ ...prev, start: e.target.value }))}
-            className="px-3 py-1 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-          />
-        </div>
-        <div>
-          <label className="block text-sm text-gray-400 mb-1">End Date</label>
-          <input
-            type="date"
-            value={dateRange.end}
-            onChange={(e) => setDateRange(prev => ({ ...prev, end: e.target.value }))}
-            className="px-3 py-1 bg-gray-700 border border-gray-600 rounded text-white text-sm focus:outline-none focus:border-blue-500"
-          />
-        </div>
+      <div className="flex flex-wrap gap-3 items-center">
+        <IndicatorToggle label="SMA" checked={showSMA} onToggle={toggleSMA} period={smaPeriod} onPeriodChange={changeSmaPeriod} />
+        <IndicatorToggle label="EMA" checked={showEMA} onToggle={toggleEMA} period={emaPeriod} onPeriodChange={changeEmaPeriod} />
+        <IndicatorToggle label="RSI" checked={showRSI} onToggle={toggleRSI} />
+        <IndicatorToggle label="MACD" checked={showMACD} onToggle={toggleMACD} />
+        <span className="text-xs text-gray-500">Double-click SMA/EMA to adjust periods.</span>
       </div>
 
       {loading && (
-        <div className="h-64 flex items-center justify-center border rounded bg-gray-900">
-          <p className="text-gray-400">Loading chart data...</p>
+        <div className="h-72 flex items-center justify-center bg-gray-900/60 rounded-lg border border-gray-700">
+          <p className="text-gray-400">Loading chart data…</p>
         </div>
       )}
 
-      {error && (
-        <div className="h-64 flex items-center justify-center border rounded bg-red-900/20">
-          <p className="text-red-400">Error: {error}</p>
+      {error && !loading && (
+        <div className="h-72 flex items-center justify-center bg-red-900/30 rounded-lg border border-red-700/60">
+          <p className="text-red-200">Error: {error}</p>
         </div>
       )}
 
-      {!loading && !error && data.length > 0 && (
-        <>
-          <PriceLineChart data={data} />
+      {!loading && !error && (!hasSelection || !hasPriceData) && (
+        <div className="h-72 flex items-center justify-center bg-gray-900/60 rounded-lg border border-gray-700 text-center">
+          <div>
+            <h4 className="text-lg font-semibold text-white mb-2">No data to display</h4>
+            <p className="text-sm text-gray-400">
+              {hasSelection
+                ? "Adjust the date range or try a different combination of tickers."
+                : "Choose at least one ticker from the list to render charts."}
+            </p>
+          </div>
+        </div>
+      )}
 
-          {latestPrice && (
-            <div className="mt-4 grid grid-cols-2 md:grid-cols-4 gap-4 p-4 bg-gray-700 rounded">
-              <div>
-                <div className="text-xs text-gray-400">Open</div>
-                <div className="text-white font-medium">${latestPrice.open.toFixed(2)}</div>
-              </div>
-              <div>
-                <div className="text-xs text-gray-400">High</div>
-                <div className="text-green-400 font-medium">${latestPrice.high.toFixed(2)}</div>
-              </div>
-              <div>
-                <div className="text-xs text-gray-400">Low</div>
-                <div className="text-red-400 font-medium">${latestPrice.low.toFixed(2)}</div>
-              </div>
-              <div>
-                <div className="text-xs text-gray-400">Volume</div>
-                <div className="text-white font-medium">{latestPrice.volume.toLocaleString()}</div>
-              </div>
+      {!loading && !error && hasPriceData && (
+        <div className="space-y-8">
+          <div className="bg-gray-900/60 rounded-lg p-4 border border-gray-700">
+            <h4 className="text-sm font-semibold text-gray-200 mb-3">Price &amp; Moving Averages</h4>
+            <ResponsiveContainer width="100%" height={360}>
+              <LineChart data={priceData} margin={{ top: 10, bottom: 10, left: 0, right: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                <XAxis
+                  dataKey="date"
+                  stroke="#9CA3AF"
+                  fontSize={12}
+                  tickFormatter={(value) => new Date(value).toLocaleDateString()}
+                />
+                <YAxis
+                  stroke="#9CA3AF"
+                  fontSize={12}
+                  tickFormatter={(value) => `$${Number(value).toFixed(2)}`}
+                />
+                <Tooltip
+                  labelFormatter={(value) => new Date(value).toLocaleDateString()}
+                  formatter={(value: any, name: string) => {
+                    if (name.toLowerCase().includes("rsi")) {
+                      return [`${Number(value).toFixed(2)}`, name];
+                    }
+                    if (name.toLowerCase().includes("macd")) {
+                      return [`${Number(value).toFixed(4)}`, name];
+                    }
+                    return [formatCurrency(value), name];
+                  }}
+                  contentStyle={{
+                    backgroundColor: "#111827",
+                    borderRadius: "8px",
+                    border: "1px solid #1F2937",
+                    color: "#F9FAFB",
+                    fontSize: "12px",
+                  }}
+                />
+                <Legend />
+                {tickers.map((ticker) => (
+                  <Line
+                    key={ticker}
+                    type="monotone"
+                    dataKey={ticker}
+                    name={`${ticker} Close`}
+                    stroke={colorMap[ticker]}
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                ))}
+                {showSMA &&
+                  tickers.map((ticker) => (
+                    <Line
+                      key={`${ticker}-sma`}
+                      type="monotone"
+                      dataKey={`${ticker}_SMA`}
+                      name={`${ticker} SMA(${smaPeriod})`}
+                      stroke={colorMap[ticker]}
+                      strokeDasharray="6 4"
+                      strokeWidth={1.5}
+                      dot={false}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                {showEMA &&
+                  tickers.map((ticker) => (
+                    <Line
+                      key={`${ticker}-ema`}
+                      type="monotone"
+                      dataKey={`${ticker}_EMA`}
+                      name={`${ticker} EMA(${emaPeriod})`}
+                      stroke={colorMap[ticker]}
+                      strokeDasharray="2 3"
+                      strokeWidth={1.5}
+                      dot={false}
+                      isAnimationActive={false}
+                    />
+                  ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          {showRSI && rsiData.length > 0 && (
+            <div className="bg-gray-900/60 rounded-lg p-4 border border-gray-700">
+              <h4 className="text-sm font-semibold text-gray-200 mb-3">Relative Strength Index</h4>
+              <ResponsiveContainer width="100%" height={220}>
+                <LineChart data={rsiData} margin={{ top: 10, bottom: 10, left: 0, right: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                  <XAxis
+                    dataKey="date"
+                    stroke="#9CA3AF"
+                    fontSize={12}
+                    tickFormatter={(value) => new Date(value).toLocaleDateString()}
+                  />
+                  <YAxis stroke="#9CA3AF" fontSize={12} domain={[0, 100]} />
+                  <Tooltip
+                    labelFormatter={(value) => new Date(value).toLocaleDateString()}
+                    formatter={(value: any) => [`${Number(value).toFixed(2)}`, "RSI"]}
+                    contentStyle={{
+                      backgroundColor: "#111827",
+                      borderRadius: "8px",
+                      border: "1px solid #1F2937",
+                      color: "#F9FAFB",
+                      fontSize: "12px",
+                    }}
+                  />
+                  <Legend />
+                  <ReferenceLine y={30} stroke="#F87171" strokeDasharray="4 4" />
+                  <ReferenceLine y={70} stroke="#34D399" strokeDasharray="4 4" />
+                  {tickers.map((ticker) => (
+                    <Line
+                      key={`${ticker}-rsi`}
+                      type="monotone"
+                      dataKey={`${ticker}_RSI`}
+                      name={`${ticker} RSI`}
+                      stroke={colorMap[ticker]}
+                      strokeWidth={1.5}
+                      dot={false}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
             </div>
           )}
-        </>
-      )}
 
-      {!loading && !error && data.length === 0 && (
-        <div className="h-64 flex items-center justify-center border rounded bg-gray-900">
-          <p className="text-gray-400">No data available for {ticker}</p>
+          {showMACD && macdData.length > 0 && (
+            <div className="bg-gray-900/60 rounded-lg p-4 border border-gray-700">
+              <h4 className="text-sm font-semibold text-gray-200 mb-3">MACD</h4>
+              <ResponsiveContainer width="100%" height={240}>
+                <LineChart data={macdData} margin={{ top: 10, bottom: 10, left: 0, right: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                  <XAxis
+                    dataKey="date"
+                    stroke="#9CA3AF"
+                    fontSize={12}
+                    tickFormatter={(value) => new Date(value).toLocaleDateString()}
+                  />
+                  <YAxis stroke="#9CA3AF" fontSize={12} tickFormatter={(value) => Number(value).toFixed(3)} />
+                  <Tooltip
+                    labelFormatter={(value) => new Date(value).toLocaleDateString()}
+                    formatter={(value: any, name: string) => [`${Number(value).toFixed(4)}`, name]}
+                    contentStyle={{
+                      backgroundColor: "#111827",
+                      borderRadius: "8px",
+                      border: "1px solid #1F2937",
+                      color: "#F9FAFB",
+                      fontSize: "12px",
+                    }}
+                  />
+                  <Legend />
+                  <ReferenceLine y={0} stroke="#9CA3AF" strokeDasharray="2 3" />
+                  {tickers.map((ticker) => (
+                    <Line
+                      key={`${ticker}-macd`}
+                      type="monotone"
+                      dataKey={`${ticker}_MACD`}
+                      name={`${ticker} MACD`}
+                      stroke={colorMap[ticker]}
+                      strokeWidth={1.5}
+                      dot={false}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                  {tickers.map((ticker) => (
+                    <Line
+                      key={`${ticker}-macd-signal`}
+                      type="monotone"
+                      dataKey={`${ticker}_MACD_SIGNAL`}
+                      name={`${ticker} Signal`}
+                      stroke={colorMap[ticker]}
+                      strokeWidth={1}
+                      strokeDasharray="4 4"
+                      dot={false}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {Object.keys(latestSnapshots).length > 0 && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {Object.entries(latestSnapshots).map(([ticker, snapshot]) => {
+                if (!snapshot) return null;
+                return (
+                  <div
+                    key={ticker}
+                    className="p-4 rounded-lg bg-gray-900/70 border border-gray-700 flex flex-col gap-2"
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-semibold text-gray-200">{ticker}</span>
+                      <span className="text-xs text-gray-400">{snapshot.date}</span>
+                    </div>
+                    <div className="text-2xl font-bold text-white">{formatCurrency(snapshot.close)}</div>
+                    <div className="grid grid-cols-2 gap-2 text-xs text-gray-400">
+                      <div>
+                        <span className="block text-gray-500 uppercase tracking-wide">High</span>
+                        <span className="text-green-300 font-medium">{formatCurrency(snapshot.high)}</span>
+                      </div>
+                      <div>
+                        <span className="block text-gray-500 uppercase tracking-wide">Low</span>
+                        <span className="text-red-300 font-medium">{formatCurrency(snapshot.low)}</span>
+                      </div>
+                      <div>
+                        <span className="block text-gray-500 uppercase tracking-wide">Open</span>
+                        <span className="text-gray-200 font-medium">{formatCurrency(snapshot.open)}</span>
+                      </div>
+                      <div>
+                        <span className="block text-gray-500 uppercase tracking-wide">Volume</span>
+                        <span className="text-gray-200 font-medium">{snapshot.volume.toLocaleString()}</span>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/components/ticker-selector.tsx
+++ b/components/ticker-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 interface TickerInfo {
   ticker: string;
@@ -11,42 +11,76 @@ interface TickerInfo {
 }
 
 interface TickerSelectorProps {
-  onTickerSelect: (ticker: string) => void;
-  selectedTicker?: string;
+  onSelectionChange: (tickers: string[]) => void;
+  selectedTickers: string[];
 }
 
-export function TickerSelector({ onTickerSelect, selectedTicker }: TickerSelectorProps) {
+function normaliseTicker(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+export function TickerSelector({ onSelectionChange, selectedTickers }: TickerSelectorProps) {
   const [tickers, setTickers] = useState<TickerInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
 
   useEffect(() => {
+    let cancelled = false;
+
     async function loadTickers() {
       try {
         const response = await fetch("/api/index");
         const data = await response.json();
 
-        if (data.tickers) {
+        if (!cancelled && data.tickers) {
           const tickerList = Array.isArray(data.tickers)
-            ? data.tickers.map((t: any) => typeof t === "string" ? { ticker: t } : t)
+            ? data.tickers.map((t: any) =>
+                typeof t === "string"
+                  ? { ticker: normaliseTicker(t) }
+                  : { ...t, ticker: normaliseTicker(t.ticker ?? "") },
+              )
             : [];
           setTickers(tickerList);
         }
       } catch (err) {
-        setError("Failed to load tickers");
-        console.error("Error loading tickers:", err);
+        if (!cancelled) {
+          setError("Failed to load tickers");
+          console.error("Error loading tickers:", err);
+        }
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }
 
     loadTickers();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  const filteredTickers = tickers.filter(ticker =>
-    ticker.ticker.toLowerCase().includes(search.toLowerCase())
-  );
+  const filteredTickers = useMemo(() => {
+    if (!search.trim()) return tickers;
+    const query = search.toLowerCase();
+    return tickers.filter((ticker) => ticker.ticker.toLowerCase().includes(query));
+  }, [tickers, search]);
+
+  const handleToggle = (ticker: string, checked: boolean) => {
+    const normalised = normaliseTicker(ticker);
+    const currentSet = new Set(selectedTickers.map(normaliseTicker));
+
+    if (checked) {
+      currentSet.add(normalised);
+    } else {
+      currentSet.delete(normalised);
+    }
+
+    onSelectionChange(Array.from(currentSet));
+  };
+
+  const handleSelectOnly = (ticker: string) => {
+    onSelectionChange([normaliseTicker(ticker)]);
+  };
 
   if (loading) {
     return (
@@ -64,11 +98,16 @@ export function TickerSelector({ onTickerSelect, selectedTicker }: TickerSelecto
     );
   }
 
+  const selectedSet = new Set(selectedTickers.map(normaliseTicker));
+
   return (
-    <div className="bg-gray-800 rounded-lg p-4">
-      <h3 className="text-lg font-semibold text-white mb-3">
-        Available Tickers ({tickers.length})
-      </h3>
+    <div className="bg-gray-800 rounded-lg p-4 flex flex-col h-full">
+      <div className="mb-3">
+        <h3 className="text-lg font-semibold text-white">Available Tickers ({tickers.length})</h3>
+        <p className="text-xs text-gray-400 mt-1">
+          Choose one or more symbols to compare. Click a ticker name to select only that symbol.
+        </p>
+      </div>
 
       <input
         type="text"
@@ -76,41 +115,58 @@ export function TickerSelector({ onTickerSelect, selectedTicker }: TickerSelecto
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         className="w-full px-3 py-2 mb-3 bg-gray-700 border border-gray-600 rounded text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
+        aria-label="Search tickers"
       />
 
-      <div className="max-h-64 overflow-y-auto">
+      <div className="max-h-64 overflow-y-auto pr-1 flex-1">
         {filteredTickers.length === 0 ? (
           <p className="text-gray-400">No tickers found</p>
         ) : (
           <div className="space-y-1">
-            {filteredTickers.map((ticker) => (
-              <button
-                key={ticker.ticker}
-                onClick={() => onTickerSelect(ticker.ticker)}
-                className={`w-full text-left px-3 py-2 rounded transition-colors ${
-                  selectedTicker === ticker.ticker
-                    ? "bg-blue-600 text-white"
-                    : "bg-gray-700 text-gray-200 hover:bg-gray-600"
-                }`}
-              >
-                <div className="flex justify-between items-center">
-                  <span className="font-medium">{ticker.ticker}</span>
-                  {ticker.records && (
-                    <span className="text-xs text-gray-400">
-                      {ticker.records.toLocaleString()} records
-                    </span>
-                  )}
+            {filteredTickers.map((ticker) => {
+              const isSelected = selectedSet.has(ticker.ticker);
+              return (
+                <div
+                  key={ticker.ticker}
+                  className={`flex items-center justify-between gap-3 px-3 py-2 rounded border transition-colors ${
+                    isSelected ? "border-blue-500 bg-blue-900/40" : "border-transparent bg-gray-700 hover:bg-gray-600"
+                  }`}
+                >
+                  <label className="flex items-center gap-2 cursor-pointer select-none text-sm text-gray-200">
+                    <input
+                      type="checkbox"
+                      className="accent-blue-500"
+                      checked={isSelected}
+                      onChange={(e) => handleToggle(ticker.ticker, e.target.checked)}
+                    />
+                    <span className="font-medium tracking-wide">{ticker.ticker}</span>
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => handleSelectOnly(ticker.ticker)}
+                    className="text-xs text-blue-300 hover:text-blue-200"
+                  >
+                    only
+                  </button>
                 </div>
-                {ticker.lastDate && (
-                  <div className="text-xs text-gray-400 mt-1">
-                    Latest: {ticker.lastDate}
-                  </div>
-                )}
-              </button>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
+
+      {selectedTickers.length > 0 && (
+        <div className="mt-4 p-3 rounded bg-blue-900/30 border border-blue-700 text-xs text-blue-100">
+          <div className="font-semibold text-sm mb-1">Selected ({selectedTickers.length})</div>
+          <div className="flex flex-wrap gap-2">
+            {selectedTickers.map((ticker) => (
+              <span key={ticker} className="px-2 py-1 bg-blue-800/60 rounded-full">
+                {ticker}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a multi-ticker dashboard workflow with indicator toggles, combined charts, and auto date controls
- wire a "create strategy with this" shortcut into the strategy lab with DSL prefilling from dashboard selections
- update documentation to reflect the enhanced dashboard analytics and shortcut workflow

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dc023ae0c8832b84d23df5f1920572